### PR TITLE
Tiny bugs

### DIFF
--- a/swingset/src/main/java/com/nqadmin/swingset/SSDBComboBox.java
+++ b/swingset/src/main/java/com/nqadmin/swingset/SSDBComboBox.java
@@ -576,28 +576,29 @@ public class SSDBComboBox extends JComboBox<SSListItem> implements SSComponentIn
 	}
 
 	/**
-	 * Removes the display text provided from the combobox and removes any
-	 * corresponding list items.
+	 * Removes the list item that has an option that equals the parameter.
 	 * <p>
-	 * If more than one item is present in the combo for the specified value, only
+	 * If more than one item is present in the combo that matches, only
 	 * the first one is removed.
 	 *
-	 * @param _displayText value of the item to be deleted.
+	 * @param _option list item with this option is deleted
 	 *
 	 * @return returns true on successful deletion otherwise returns false.
 	 */
-	public boolean deleteStringItem(final String _displayText) {
+	public boolean deleteStringItem(final Object _option) {
 
 		boolean result = false;
 
-		// TODO: javadoc says "list items" plural. Is that what's wanted.
 		try (Model.Remodel remodel = comboInfo.getRemodel()) {
-			final int index = remodel.getOptions().indexOf(_displayText);
-			result = deleteItem(index);
+			final int index = remodel.getOptions().indexOf(_option);
+			if (index != -1) {
+				remodel.remove(index);
+				result = true;
+			}
 		}
 
 		// if (options != null) {
-		// 	final int index = options.indexOf(_displayText);
+		// 	final int index = options.indexOf(_option);
 		// 	result = deleteItem(mappings.get(index));
 		// }
 

--- a/swingset/src/test/java/com/nqadmin/swingset/models/AbstractComboBoxListSwingModelTest.java
+++ b/swingset/src/test/java/com/nqadmin/swingset/models/AbstractComboBoxListSwingModelTest.java
@@ -299,19 +299,27 @@ public class AbstractComboBoxListSwingModelTest {
 			assertTrue(getElemEquals(elems, testItemIndex, remodel));
 
 			SSListItem testItem = linfo.createListItem((Object[])elems);
-			SSListItem getItem = remodel.get(testItemIndex);
-			assertTrue(testItem.equals(getItem));
+			SSListItem originalListItem = remodel.get(testItemIndex);
+			assertTrue(testItem.equals(originalListItem));
 
 			int modElemIndex = 2 % nElem;
 			// create a testItem that won't match what's in the item list
 			elems[modElemIndex] = 99;
 			testItem = linfo.createListItem((Object[])elems);
-			assertFalse(testItem.equals(getItem));
+			assertFalse(testItem.equals(originalListItem));
 
 			// modify the element in the list item, should match now
 			// note, using the same reference for item in the list
 			remodel.setElem(testItemIndex, modElemIndex, 99);
-			assertTrue(testItem.equals(getItem));
+			// should be a clone, so must refetch
+			SSListItem newListItem = remodel.get(testItemIndex);
+			assertTrue(testItem.equals(newListItem));
+
+			// try the clone directly
+			SSListItem cloneListItem = linfo.getClone(newListItem);
+			assertTrue(newListItem.equals(cloneListItem));
+			assertTrue(newListItem != cloneListItem);
+
 
 			// change the item to 70,71,72,73
 			for (int i = 0; i < nElem; i++) {


### PR DESCRIPTION
Comments in source. 2 fixes. 

- SSDBComboBox#deleteStringItem was removing wrong item.
- AbstractComboBoxListSwingModel#setElem didn't notify glazed lists that the contents of a listItem changed.