### PR TITLE
Get selected value

### DIFF
--- a/swingset-demo/src/main/java/com/nqadmin/swingset/demo/TestBaseComponents.java
+++ b/swingset-demo/src/main/java/com/nqadmin/swingset/demo/TestBaseComponents.java
@@ -317,7 +317,6 @@ public class TestBaseComponents extends JFrame {
 			// SETUP NAVIGATOR QUERY
 				final String query = "SELECT * FROM swingset_base_test_data;";
 				cmbSSDBComboNav = new SSDBComboBox(connection, query, "swingset_base_test_pk", "swingset_base_test_pk");
-				cmbSSDBComboNav.setLogColumnName("combo_nav");
 
 				try {
 					cmbSSDBComboNav.execute();

--- a/swingset-demo/src/main/java/com/nqadmin/swingset/demo/TestBaseComponents.java
+++ b/swingset-demo/src/main/java/com/nqadmin/swingset/demo/TestBaseComponents.java
@@ -185,7 +185,9 @@ public class TestBaseComponents extends JFrame {
 	/**
 	 * combo navigator and sync manger
 	 */
-	SSDBComboBox cmbSSDBComboNav = new SSDBComboBox(); // SSDBComboBox used just for navigation
+	// TODO: this gets set again, why set it here? listeners?
+	//SSDBComboBox cmbSSDBComboNav = new SSDBComboBox(); // SSDBComboBox used just for navigation
+	final SSDBComboBox cmbSSDBComboNav; // SSDBComboBox used just for navigation
 	SSSyncManager syncManager;
 
 	/**
@@ -315,6 +317,7 @@ public class TestBaseComponents extends JFrame {
 			// SETUP NAVIGATOR QUERY
 				final String query = "SELECT * FROM swingset_base_test_data;";
 				cmbSSDBComboNav = new SSDBComboBox(connection, query, "swingset_base_test_pk", "swingset_base_test_pk");
+				cmbSSDBComboNav.setLogColumnName("combo_nav");
 
 				try {
 					cmbSSDBComboNav.execute();

--- a/swingset/src/main/java/com/nqadmin/swingset/SSDBComboBox.java
+++ b/swingset/src/main/java/com/nqadmin/swingset/SSDBComboBox.java
@@ -81,6 +81,11 @@ import com.nqadmin.swingset.models.SSListItemFormat;
  * represents a foreign key to another table, and the combobox needs to display
  * a list of one (or more) columns from the other table.
  * <p>
+ * <b>Warning. This combobox may use GlazedLists. Do not use methods
+ * that are based on index in the list. Unless you're sure...</b>
+ * setSelectedIndex(-1) is OK, though it may end up at selected
+ * index 0, which is "null/empty" if allowing null.
+ * <p>
  * Note, if changing both a rowSet and column name consider using the bind()
  * method rather than individual setRowSet() and setColumName() calls.
  * <p>
@@ -1347,6 +1352,9 @@ public class SSDBComboBox extends JComboBox<SSListItem> implements SSComponentIn
 				// The next statement either selects
 				// the first item in combo, or a null.
 				super.setSelectedItem(nullItem);
+				if (nullItem == null) {
+					logger.debug(() -> String.format("%s : Setting null when null not allowed. Current editor text is '%s'", getColumnForLog(), getEditor().getItem()));
+				}
 				// if (nullItem != null) {
 				// 	super.setSelectedItem(nullItem);
 				// } else {
@@ -1508,12 +1516,23 @@ public class SSDBComboBox extends JComboBox<SSListItem> implements SSComponentIn
 					// SPECIFIED TEXT IS STORED
 					//final int index = options.indexOf(_value);
 					final int index = remodel.getOptions().indexOf(_value);
-					
-					if (index == -1) {
-						logger.warn(getColumnForLog() + ": Could not find a corresponding item in combobox for display text of " + _value + ". Setting index to -1 (blank).");
+
+					SSListItem item = null;
+					if (index != -1) {
+						item = remodel.get(index);
+					} else {
+						logger.warn(getColumnForLog() + ": Could not find a corresponding item in combobox for display text of " + _value + ". Setting selectedItem to null (blank).");
 					}
 					
-					setSelectedIndex(index);
+					//
+					// TODO: GET RID OF THIS, USE ITEM OR SOME OTHER TECHNIQUE,
+					//       NOT RELIABLE WITH GLAZED LISTS
+					//
+					// setSelectedIndex()->setSelectedItem().
+					// setSelectedIndex(index);
+
+					setSelectedItem(item);
+
 					//updateUI();
 					
 				}

--- a/swingset/src/main/java/com/nqadmin/swingset/SSDBComboBox.java
+++ b/swingset/src/main/java/com/nqadmin/swingset/SSDBComboBox.java
@@ -191,7 +191,9 @@ public class SSDBComboBox extends JComboBox<SSListItem> implements SSComponentIn
 
 	/**
 	 * Value to represent that no item has been selected in the combo box.
+	 * @deprecated 
 	 */
+	@Deprecated
 	public static final int NON_SELECTED = Integer.MIN_VALUE + 1;
 
 	/** when null allowed, this is the null item. if null, not allowed */
@@ -330,11 +332,11 @@ public class SSDBComboBox extends JComboBox<SSListItem> implements SSComponentIn
 	 */
 	protected String secondDisplayColumnName = null;
 
-	/**
-	 * SSListItem currently selected in combobox. Needed because GlazedList can cause getSelectedIndex()
-	 * to return -1 (while editing) or 0 (after selection is made from list subset)
-	 */
-	private SSListItem selectedItem = null;
+	// /**
+	//  * SSListItem currently selected in combobox. Needed because GlazedList can cause getSelectedIndex()
+	//  * to return -1 (while editing) or 0 (after selection is made from list subset)
+	//  */
+	// private SSListItem selectedItem = null;
 
 	/**
 	 * Alphanumeric separator used to separate values in multi-column comboboxes.
@@ -344,10 +346,10 @@ public class SSDBComboBox extends JComboBox<SSListItem> implements SSComponentIn
 	//protected String separator = " - ";
 	protected String separator = " | ";
 
-	/**
-	 * Boolean to indicated that a call to setSelectedItem() is in progress.
-	 */
-	private boolean settingSelectedItem = false;
+	// /**
+	//  * Boolean to indicated that a call to setSelectedItem() is in progress.
+	//  */
+	// private boolean settingSelectedItem = false;
 
 	/**
 	 * Common fields shared across SwingSet components
@@ -845,8 +847,10 @@ public class SSDBComboBox extends JComboBox<SSListItem> implements SSComponentIn
 
 		// TODO Leaking NON_SELECTED. Use null? Use -1? Use Long.MIN_VALUE?
 		
-		logger.trace(String.format("%s: getSelectedValue(), fromSet %b:%s, selectedIndex %d.",
-				getColumnForLog(), settingSelectedItem, selectedItem, getSelectedIndex()));
+		logger.trace(() -> String.format("%s: getSelectedValue(), idx:val %d:%s.",
+				getColumnForLog(), getSelectedIndex(), getSelectedItem()));
+		// logger.trace(String.format("%s: getSelectedValue(), fromSet %b:%s, selectedIndex %d.",
+		// 		getColumnForLog(), settingSelectedItem, selectedItem, getSelectedIndex()));
 
 		Long result = null;
 
@@ -874,11 +878,15 @@ public class SSDBComboBox extends JComboBox<SSListItem> implements SSComponentIn
 //					
 //				}
 //			}
-			if (settingSelectedItem && selectedItem != null) {
-				result = remodel.getMapping(selectedItem);
-			} else if (getSelectedIndex() != -1) {
-				result = remodel.getMapping(getSelectedIndex());
+			Object item = getSelectedItem();
+			if (item instanceof SSListItem) {
+				result = remodel.getMapping((SSListItem)item);
 			}
+			// if (settingSelectedItem && selectedItem != null) {
+			// 	result = remodel.getMapping(selectedItem);
+			// } else if (getSelectedIndex() != -1) {
+			// 	result = remodel.getMapping(getSelectedIndex());
+			// }
 		}
 // 2020-12-03: Changing method signature to Long so we can now return null.
 //		// If anything above returned null, change to NON_SELECTED.
@@ -1295,16 +1303,16 @@ public class SSDBComboBox extends JComboBox<SSListItem> implements SSComponentIn
 	 */
 	@Override
 	public void setSelectedItem(final Object _value) {
-		logger.debug(() -> String.format("%s: setSelectedItem(%s), allowNull? %b",
+		logger.debug(() -> String.format("%s: setSelectedItem(%s), allowNull %b",
 				getColumnForLog(), _value, getAllowNull()));
 
 // TODO Need to deal with null on focus lost event. SSDBComboListener.actionPerformed setting bound column to  null when focus lost.
 
 // INTERCEPTING GLAZEDLISTS CALLS TO setSelectedItem() SO THAT WE CAN PREVENT IT FROM TRYING TO SET VALUES NOT IN THE LIST
 
-		settingSelectedItem = true;
+		// settingSelectedItem = true;
 
-		try {
+		// try {
 
 // NOTE THAT CALLING setSelectedIndex(-1) IN THIS METHOD CAUSES  CYCLE HERE BECAUSE setSelectedIndex() CALLS setSelectedItem()
 
@@ -1321,7 +1329,7 @@ public class SSDBComboBox extends JComboBox<SSListItem> implements SSComponentIn
 
 		// Extract selected item
 			//selectedItem = (SSListItem) _value;
-			selectedItem = (SSListItem) _value;
+			SSListItem selectedItem = (SSListItem) _value;
 
 		// Call to super.setSelectedItem() triggers SSDBComboListener.actionPerformed, which calls getSelectedValue(), which calls getSelectedIndex(), which returns -1 while still in the editor
 		// and returns 0 after focus is lost.
@@ -1333,21 +1341,23 @@ public class SSDBComboBox extends JComboBox<SSListItem> implements SSComponentIn
 			if (selectedItem!=null) {
 				super.setSelectedItem(_value);
 				getEditor().selectAll(); // after we find a match, do a select all on the editor so if the user starts typing again it won't be appended
-				logger.debug("{}: Selected Index AFTER setSelectedItem()={}", () -> getColumnForLog(), () -> getSelectedIndex());
+				logger.debug("{}: Selected Index AFTER super.setSelectedItem()={}", () -> getColumnForLog(), () -> getSelectedIndex());
 			} else {
 				if (nullItem != null) {
 					super.setSelectedItem(nullItem);
 				} else {
+					// TODO: why not super.setSelectedItem(null)?
+					//       BTW: can't make this happen now
 					logger.debug("{}: No matching list item found so not updating. Current editor text is '{}'", () -> getColumnForLog(), () -> getEditor().getItem().toString());
 				}
 			}
 
 
 
-		} finally {
-			settingSelectedItem = false;
-			selectedItem = null;
-		}
+		// } finally {
+		// 	settingSelectedItem = false;
+		// 	selectedItem = null;
+		// }
 
 		//return;
 

--- a/swingset/src/main/java/com/nqadmin/swingset/SSDBComboBox.java
+++ b/swingset/src/main/java/com/nqadmin/swingset/SSDBComboBox.java
@@ -845,7 +845,8 @@ public class SSDBComboBox extends JComboBox<SSListItem> implements SSComponentIn
 
 		// TODO Leaking NON_SELECTED. Use null? Use -1? Use Long.MIN_VALUE?
 		
-		logger.trace("{}: Call to getSelectedValue().", () -> getColumnForLog());
+		logger.trace(String.format("%s: getSelectedValue(), fromSet %b:%s, selectedIndex %d.",
+				getColumnForLog(), settingSelectedItem, selectedItem, getSelectedIndex()));
 
 		Long result = null;
 
@@ -1294,6 +1295,8 @@ public class SSDBComboBox extends JComboBox<SSListItem> implements SSComponentIn
 	 */
 	@Override
 	public void setSelectedItem(final Object _value) {
+		logger.debug(() -> String.format("%s: setSelectedItem(%s), allowNull? %b",
+				getColumnForLog(), _value, getAllowNull()));
 
 // TODO Need to deal with null on focus lost event. SSDBComboListener.actionPerformed setting bound column to  null when focus lost.
 
@@ -1304,7 +1307,6 @@ public class SSDBComboBox extends JComboBox<SSListItem> implements SSComponentIn
 		try {
 
 // NOTE THAT CALLING setSelectedIndex(-1) IN THIS METHOD CAUSES  CYCLE HERE BECAUSE setSelectedIndex() CALLS setSelectedItem()
-		logger.debug("{}: Selected Item=" + _value, () -> getColumnForLog());
 
 //		logger.debug("{}: Selected Index BEFORE hidePopup()={}", () -> getColumnForLog(), () -> getSelectedIndex());
 //

--- a/swingset/src/main/java/com/nqadmin/swingset/SSDBComboBox.java
+++ b/swingset/src/main/java/com/nqadmin/swingset/SSDBComboBox.java
@@ -197,7 +197,7 @@ public class SSDBComboBox extends JComboBox<SSListItem> implements SSComponentIn
 	public static final int NON_SELECTED = Integer.MIN_VALUE + 1;
 
 	/** when null allowed, this is the null item. if null, not allowed */
-	private static SSListItem nullItem;
+	private SSListItem nullItem;
 
 	/**
 	 * Start with option2 disabled
@@ -1343,13 +1343,15 @@ public class SSDBComboBox extends JComboBox<SSListItem> implements SSComponentIn
 				getEditor().selectAll(); // after we find a match, do a select all on the editor so if the user starts typing again it won't be appended
 				logger.debug("{}: Selected Index AFTER super.setSelectedItem()={}", () -> getColumnForLog(), () -> getSelectedIndex());
 			} else {
-				if (nullItem != null) {
-					super.setSelectedItem(nullItem);
-				} else {
-					// TODO: why not super.setSelectedItem(null)?
-					//       BTW: can't make this happen now
-					logger.debug("{}: No matching list item found so not updating. Current editor text is '{}'", () -> getColumnForLog(), () -> getEditor().getItem().toString());
-				}
+				// Note that nullItem is null when allowNull is false.
+				// The next statement either selects
+				// the first item in combo, or a null.
+				super.setSelectedItem(nullItem);
+				// if (nullItem != null) {
+				// 	super.setSelectedItem(nullItem);
+				// } else {
+				// 	logger.debug("{}: No matching list item found so not updating. Current editor text is '{}'", () -> getColumnForLog(), () -> getEditor().getItem().toString());
+				// }
 			}
 
 

--- a/swingset/src/main/java/com/nqadmin/swingset/datasources/RowSetOps.java
+++ b/swingset/src/main/java/com/nqadmin/swingset/datasources/RowSetOps.java
@@ -54,6 +54,7 @@ import javax.sql.RowSet;
 
 import org.apache.logging.log4j.LogManager;
 
+import com.nqadmin.swingset.SSDataNavigator;
 import com.nqadmin.swingset.utils.SSCommon;
 
 // RowSetOps.java
@@ -289,13 +290,13 @@ public class RowSetOps {
 		return getJDBCType(getColumnType(_resultSet, _columnName));
 	}
 
-	private static EnumSet<JDBCType> textUpdateEmptyOK = EnumSet.of(
+	private static final EnumSet<JDBCType> textUpdateEmptyOK = EnumSet.of(
 			JDBCType.CHAR,
 			JDBCType.VARCHAR,
 			JDBCType.LONGVARCHAR
 	);
 	
-	private static EnumSet<JDBCType> textUpdateOK = EnumSet.of(
+	private static final EnumSet<JDBCType> textUpdateOK = EnumSet.of(
 			JDBCType.INTEGER,
 			JDBCType.SMALLINT,
 			JDBCType.TINYINT,
@@ -343,6 +344,11 @@ public class RowSetOps {
 			return;
 		}
 
+		if (_updatedValue == null && SSDataNavigator.isInserting(_rowSet)) {
+			_rowSet.updateNull(_columnName);
+			return;
+		}
+
 		/*
 		 * FIRST - NULL HANDLING:
 		 * 
@@ -378,6 +384,7 @@ public class RowSetOps {
                 throw new NullPointerException("Null values are not allowed for this field.");
             }
         }
+		assert(_updatedValue != null);
 
 		/*
 		 * SECOND - WRITING NON-NULL VALUES TO DATABASE BASED ON APPROPRIATE STRING CONVERSIONS
@@ -527,7 +534,7 @@ public class RowSetOps {
 
 	// TODO: for override of type mapping for local/dbms requirements
 	// with_timezone might be the perfect candidates
-	private static EnumMap<JDBCType, Class<?>> overrideJdbcToJavaType = new EnumMap<JDBCType, Class<?>>(JDBCType.class);
+	private static final EnumMap<JDBCType, Class<?>> overrideJdbcToJavaType = new EnumMap<JDBCType, Class<?>>(JDBCType.class);
 	/**
 	 * Determine the Java type class for the given database type.
 	 * @param _jdbcType JDBCType of interest

--- a/swingset/src/main/java/com/nqadmin/swingset/utils/SSCommon.java
+++ b/swingset/src/main/java/com/nqadmin/swingset/utils/SSCommon.java
@@ -56,7 +56,9 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import com.nqadmin.swingset.datasources.RowSetOps;
+
 import java.sql.Connection;
+import java.util.Objects;
 
 // SSCommon.java
 //
@@ -754,7 +756,16 @@ public class SSCommon implements Serializable {
 	 * @param _logColumnName text
 	 */
 	public void setLogColumnName(final String _logColumnName) {
+		Objects.requireNonNull(_logColumnName);
 		logColumnName = _logColumnName;
+	}
+
+	/**
+	 * Name/text to display in log messages if boundColumnName is not set.
+	 * @return text for log entries, null if never set
+	 */
+	public String getLogColumnName() {
+		return logColumnName;
 	}
 
 	/**

--- a/swingset/src/main/java/com/nqadmin/swingset/utils/SSCommon.java
+++ b/swingset/src/main/java/com/nqadmin/swingset/utils/SSCommon.java
@@ -307,9 +307,14 @@ public class SSCommon implements Serializable {
 	private String boundColumnName = null;
 
 	/**
-	 * Column SQL data type.
+	 * Name for log in boundColumnName is not set.
 	 */
-	private int boundColumnType = java.sql.Types.NULL;
+	private String logColumnName = null;
+
+	// /**
+	//  * Column SQL data type.
+	//  */
+	// private int boundColumnType = java.sql.Types.NULL;
 
 	/**
 	 * flag to indicate if we're inside of a bind() method
@@ -547,7 +552,8 @@ public class SSCommon implements Serializable {
 	 * @return the data type of the bound column
 	 */
 	public int getBoundColumnType() {
-		return boundColumnType;
+		// return boundColumnType;
+		return boundColumnJDBCType.getVendorTypeNumber();
 	}
 
 	/**
@@ -556,7 +562,7 @@ public class SSCommon implements Serializable {
 	 * @return the boundColumnName in square brackets
 	 */
 	public String getColumnForLog() {
-		return "[" + boundColumnName + "]";
+		return "[" + (boundColumnName != null ? boundColumnName : logColumnName) + "]";
 	}
 
 	/**
@@ -679,6 +685,7 @@ public class SSCommon implements Serializable {
 		try {
 			// IF COLUMN INDEX IS VALID, GET COLUMN NAME, OTHERWISE SET TO NULL
 // TODO Update RowSet to return constant or throw Exception if invalid/out of bounds.
+			int boundColumnType;
 			if (boundColumnIndex != NO_COLUMN_INDEX) {
 				//boundColumnName = getRowSet().getColumnName(boundColumnIndex);
 				//boundColumnType = getRowSet().getColumnType(boundColumnIndex);
@@ -720,6 +727,7 @@ public class SSCommon implements Serializable {
 			// IF COLUMN NAME ISN'T NULL, SET COLUMN INDEX - OTHERWISE, SET INDEX TO
 			// NO_INDEX
 // TODO Update RowSet to return constant or throw Exception if invalid/out of bounds.
+			int boundColumnType;
 			if (boundColumnName != null) {
 				//boundColumnIndex = getRowSet().getColumnIndex(boundColumnName);
 				//boundColumnType = getRowSet().getColumnType(boundColumnIndex);
@@ -739,6 +747,14 @@ public class SSCommon implements Serializable {
 		if (!inBinding) {
 			bind();
 		}
+	}
+
+	/**
+	 * Name/text to display in log messages if boundColumnName is not set.
+	 * @param _logColumnName text
+	 */
+	public void setLogColumnName(final String _logColumnName) {
+		logColumnName = _logColumnName;
 	}
 
 	/**

--- a/swingset/src/main/java/com/nqadmin/swingset/utils/SSComponentInterface.java
+++ b/swingset/src/main/java/com/nqadmin/swingset/utils/SSComponentInterface.java
@@ -407,6 +407,14 @@ public interface SSComponentInterface {
 	}
 
 	/**
+	 * Set the text for log entries; only used if boundColumnName is null.
+	 * @param _boundColumnName
+	 */
+	default void setLogColumnName(final String _boundColumnName) {
+		getSSCommon().setLogColumnName(_boundColumnName);
+	}
+
+	/**
 	 * Sets the value of the bound database column
 	 *
 	 * @param _boundColumnText the value to set in the bound database column

--- a/swingset/src/main/java/com/nqadmin/swingset/utils/SSComponentInterface.java
+++ b/swingset/src/main/java/com/nqadmin/swingset/utils/SSComponentInterface.java
@@ -415,6 +415,14 @@ public interface SSComponentInterface {
 	}
 
 	/**
+	 * Get the text for log entries; only used if boundColumnName is null.
+	 * @return text for log entries, null if never set
+	 */
+	default String getLogColumnName() {
+		return getSSCommon().getLogColumnName();
+	}
+
+	/**
 	 * Sets the value of the bound database column
 	 *
 	 * @param _boundColumnText the value to set in the bound database column

--- a/swingset/src/main/java/com/nqadmin/swingset/utils/SSSyncManager.java
+++ b/swingset/src/main/java/com/nqadmin/swingset/utils/SSSyncManager.java
@@ -303,6 +303,10 @@ public class SSSyncManager {
 		dataNavigator = _dataNavigator;
 		rowset = dataNavigator.getRowSet();
 		dataNavigator.setNavCombo(comboBox);
+		if (_comboBox.getLogColumnName() == null) {
+			_comboBox.setLogColumnName(String.format("**ComboBoxNavigator@%x**",
+					System.identityHashCode(_comboBox)));
+		}
 	}
 	
 	/**


### PR DESCRIPTION
It seems that the two commits are combined in the diffs, can click on a commit to see it separately.

The first commit adds some debug to SSDBComboBox. And introduces setLogColumnName; it was added that after engaging with a wild goose around some `null` in log entries. Also, get rid of `boundColumnType` in SSCommon.

The second  gets rid of settingSelectedItem/selectedItem. And there's a comment about simplifying the "else" in setSelectedItem which I believe can be done.