### PR TITLE
Handling of null and empty string on insert

### DIFF
--- a/swingset/src/main/java/com/nqadmin/swingset/datasources/RowSetOps.java
+++ b/swingset/src/main/java/com/nqadmin/swingset/datasources/RowSetOps.java
@@ -383,7 +383,8 @@ public class RowSetOps {
 			return;
 		}
 
-		if (_updatedValue == null && SSDataNavigator.isInserting(_rowSet)) {
+		// On insert row, write null if updatedValue is null or empty string, and do not perform other checks. 
+		if ((_updatedValue == null || _updatedValue.isEmpty()) && SSDataNavigator.isInserting(_rowSet)) {
 			_rowSet.updateNull(_columnName);
 			return;
 		}

--- a/swingset/src/main/java/com/nqadmin/swingset/formatting/SSFormattedTextField.java
+++ b/swingset/src/main/java/com/nqadmin/swingset/formatting/SSFormattedTextField.java
@@ -57,6 +57,7 @@ import javax.swing.SwingUtilities;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import com.nqadmin.swingset.SSDataNavigator;
 import com.nqadmin.swingset.datasources.RowSetOps;
 import com.nqadmin.swingset.utils.SSCommon;
 import com.nqadmin.swingset.utils.SSComponentInterface;
@@ -178,7 +179,8 @@ public class SSFormattedTextField extends JFormattedTextField
 			    logger.info(getColumnForLog() + ": Object to be passed to database is " + currentValue + ".");
 
 			    // TODO May want to see if we can veto invalid updates
-			    if (!getAllowNull() && (currentValue==null)) {
+			    // 2020-12-14_BP: allow null if on insert row
+			    if (!getAllowNull() && (currentValue==null) && !SSDataNavigator.isInserting(getRowSet())) {
 			    	logger.warn("Null value encounted, but not allowed.");
 					JOptionPane.showMessageDialog(ftf,
 							"Null values are not allowed for " + getBoundColumnName(), "Null Exception", JOptionPane.ERROR_MESSAGE);


### PR DESCRIPTION
@errael 

RowSetOps.updateColumnText() was not handling empty strings well on the insert row for columns that were not null based on metadata.

SSFormattedTextField had its own popups if getAllowNull() was false. Now won't give the warning on the insert row.