### PR TITLE
More predictable behavior for combos

### DIFF
--- a/swingset-demo/src/main/java/com/nqadmin/swingset/demo/Example3.java
+++ b/swingset-demo/src/main/java/com/nqadmin/swingset/demo/Example3.java
@@ -186,7 +186,8 @@ public class Example3 extends JFrame {
 					rs.close();
 
 				// SET OTHER DEFAULTS
-//					 cmbSupplierName.setSelectedValue(0);
+					 logger.debug("Setting default for Supplier Name mapping to 2.");
+					 cmbSupplierName.setSelectedMapping((long) 2);
 //					 cmbPartName.setSelectedValue(0);
 //					 txtQuantity.setText("0");
 

--- a/swingset/src/main/java/com/nqadmin/swingset/SSBaseComboBox.java
+++ b/swingset/src/main/java/com/nqadmin/swingset/SSBaseComboBox.java
@@ -132,7 +132,7 @@ public abstract class SSBaseComboBox<M,O,O2> extends JComboBox<SSListItem> imple
 			//
 			// Could be combined with next block, but keeping them separate for debugging.
 			// May be able to eliminate actionListenerNoUpdate when GlazedLists fully supports STRICT/CONTAINS
-			if (getBoundColumnName() == null) {
+			if (isComboBoxNavigator()) {
 				logger.debug("{}: Action Listener returning. No bound column.", () -> getColumnForLog());
 				return;
 			}

--- a/swingset/src/main/java/com/nqadmin/swingset/SSBaseComboBox.java
+++ b/swingset/src/main/java/com/nqadmin/swingset/SSBaseComboBox.java
@@ -522,7 +522,7 @@ public abstract class SSBaseComboBox<M,O,O2> extends JComboBox<SSListItem> imple
 			priorEditorText = currentEditorText;
 			// 2020-12-29_BP: CONFIRMED selectAll() IS NEEDED FOLLOWING A NORMAL ITEM SELECTION
 			//   OTHERWISE USER IS APPENDING EXISTING ITEM STRING IF THEY START TO TYPE
-			if (getEditor() != null && getEditor().getEditorComponent().hasFocus()) {
+			if (getEditor().getEditorComponent().hasFocus()) {
 				// after we find a match, do a select all on the editor so
 				// if the user starts typing again it won't be appended
 				// 2020-12-21_BP: if we don't limited to field with focus, the comboboxes blink on navigation

--- a/swingset/src/main/java/com/nqadmin/swingset/SSBaseComboBox.java
+++ b/swingset/src/main/java/com/nqadmin/swingset/SSBaseComboBox.java
@@ -42,8 +42,6 @@ package com.nqadmin.swingset;
 import java.awt.Dimension;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
-import java.awt.event.FocusEvent;
-import java.awt.event.FocusListener;
 import java.awt.event.KeyAdapter;
 import java.awt.event.KeyEvent;
 import java.io.Serializable;

--- a/swingset/src/main/java/com/nqadmin/swingset/SSBaseComboBox.java
+++ b/swingset/src/main/java/com/nqadmin/swingset/SSBaseComboBox.java
@@ -121,8 +121,14 @@ public abstract class SSBaseComboBox<M,O,O2> extends JComboBox<SSListItem> imple
 		private static final long serialVersionUID = -3131533966245488092L;
 
 		/**
-		 * For JComboBox ActionListener and ItemListener are very similar.
+		 * For JComboBox ActionListener and ItemListener are similar, but ActionListener
+		 * seems more appropriate since we don't care about the de-selection of the
+		 * previously selected item.
 		 * 
+		 * Per https://docs.oracle.com/javase/tutorial/uiswing/components/combobox.html#listeners
+		 * ActionListener just tells us that the selection changed whereas ItemListener fires
+		 * separate events for deselection of previous item and selection of current item.
+		 *
 		 * {@inheritDoc} */
 		@Override
 		public void actionPerformed(final ActionEvent ae) {

--- a/swingset/src/main/java/com/nqadmin/swingset/SSBaseComboBox.java
+++ b/swingset/src/main/java/com/nqadmin/swingset/SSBaseComboBox.java
@@ -877,11 +877,22 @@ public abstract class SSBaseComboBox<M,O,O2> extends JComboBox<SSListItem> imple
 		M mapping = getSelectedMapping();
 	
 		if (mapping == null) {
+			logger.debug(() -> String.format("%s: Setting to null.", getColumnForLog()));
 			setBoundColumnText(null);
-			logger.debug(() -> String.format("%s: Setting column to null.", getColumnForLog()));
 		} else {
-			setBoundColumnText(String.valueOf(mapping));
-			logger.debug(String.format("%s: Setting column to %s.",  getColumnForLog(), mapping));
+			logger.debug(String.format("%s: Setting to %s.",  getColumnForLog(), mapping));
+			// TODO: need to avoid setting to same value
+			// for NavGroupState. Wonder why, avoids event?
+			//setBoundColumnText(String.valueOf(mapping));
+
+			// not sure this is a reliable way to check.
+			// TODO: check should probably be in
+			//       setBoundColumnText or RowSetOps.updateColumnText
+
+			String tStringMapping = String.valueOf(mapping);
+			if (!getBoundColumnText().equals(tStringMapping)) {
+				setBoundColumnText(tStringMapping);
+			}
 		}
 	
 		addRowSetListener();

--- a/swingset/src/main/java/com/nqadmin/swingset/SSComboBox.java
+++ b/swingset/src/main/java/com/nqadmin/swingset/SSComboBox.java
@@ -822,6 +822,45 @@ public class SSComboBox extends SSBaseComboBox<Integer, String, Object>
 
 	// }
 
+//	/**
+//	 * Updates the value stored and displayed in the SwingSet component based on
+//	 * getBoundColumnText()
+//	 * <p>
+//	 * Call to this method should be coming from SSCommon and should already have
+//	 * the Component listener removed
+//	 */
+//	@Override
+//	public void updateSSComponent() {
+//		
+//		// TODO Modify this class similar to updateSSComponent() in SSFormattedTextField and only allow JDBC types that convert to Long or Integer
+//		
+//		try {
+//			if (!hasItems()) {
+//				return;
+//			}
+//
+//			// Expecting an integer so trim in case the database column is a String AND has padding
+//			// TODO: #17 string casting
+//			final String rawText = getBoundColumnText();
+//			logger.debug("{}: getBoundColumnText() returns {}.", () -> getColumnForLog(), () -> rawText);
+//			final String trimmedText = rawText != null ? rawText.trim() : null;
+//
+//			// GET THE INTEGER EQUIVALENT OF THE TEXT IN THE TEXT FIELD
+//			if ((trimmedText != null) && !(trimmedText.isEmpty())) {
+//				final int comboCode = Integer.parseInt(trimmedText);
+//
+//				setSelectedMapping(comboCode);
+//
+//			} else {
+//				//setSelectedIndex(-1);
+//				setSelectedItem(nullItem);
+//			}
+//
+//		} catch (final NumberFormatException nfe) {
+//			logger.warn(getColumnForLog() + ": Number Format Exception.", nfe);
+//		}
+//	}
+	
 	/**
 	 * Updates the value stored and displayed in the SwingSet component based on
 	 * getBoundColumnText()
@@ -831,33 +870,38 @@ public class SSComboBox extends SSBaseComboBox<Integer, String, Object>
 	 */
 	@Override
 	public void updateSSComponent() {
-		
-		// TODO Modify this class similar to updateSSComponent() in SSFormattedTextField and only allow JDBC types that convert to Long or Integer
-		
+		// TODO Modify this class similar to updateSSComponent() in SSFormattedTextField and only limit JDBC types accepted
 		try {
+			// If initialization is taking place then there won't be any mappings so don't try to update anything yet.
 			if (!hasItems()) {
 				return;
 			}
 
-			// Expecting an integer so trim in case the database column is a String AND has padding
-			// TODO: #17 string casting
-			final String rawText = getBoundColumnText();
-			logger.debug("{}: getBoundColumnText() returns {}.", () -> getColumnForLog(), () -> rawText);
-			final String trimmedText = rawText != null ? rawText.trim() : null;
+			// SSDBComboBox will generally work with primary key column data queried from the database, which will generally be of data type long.
+			// SSComboBox is generally used with 2 or 4 byte integer columns.
+			final String boundColumnText = getBoundColumnText();
 
-			// GET THE INTEGER EQUIVALENT OF THE TEXT IN THE TEXT FIELD
-			if ((trimmedText != null) && !(trimmedText.isEmpty())) {
-				final int comboCode = Integer.parseInt(trimmedText);
+			// LOGGING
+			logger.debug("{}: getBoundColumnText() - " + boundColumnText, () -> getColumnForLog());
 
-				setSelectedMapping(comboCode);
-
-			} else {
-				//setSelectedIndex(-1);
+			// GET THE BOUND VALUE STORED IN THE ROWSET - may throw a NumberFormatException
+			Integer targetValue = null;
+			if ((boundColumnText != null) && !boundColumnText.isEmpty()) {
+				targetValue = Integer.parseInt(boundColumnText);
+			}
+			
+			// LOGGING
+			logger.debug("{}: targetValue - " + targetValue, () -> getColumnForLog());
+			
+			// UPDATE COMPONENT
+			if (targetValue==null) {
 				setSelectedItem(nullItem);
+			} else {
+				setSelectedMapping(targetValue);
 			}
 
 		} catch (final NumberFormatException nfe) {
-			logger.warn(getColumnForLog() + ": Number Format Exception.", nfe);
+			logger.error(getColumnForLog() + ": Number Format Exception.", nfe);
 		}
 	}
 

--- a/swingset/src/main/java/com/nqadmin/swingset/SSComboBox.java
+++ b/swingset/src/main/java/com/nqadmin/swingset/SSComboBox.java
@@ -47,6 +47,7 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import javax.swing.JComboBox;
+import javax.swing.JOptionPane;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -901,6 +902,8 @@ public class SSComboBox extends SSBaseComboBox<Integer, String, Object>
 			}
 
 		} catch (final NumberFormatException nfe) {
+			JOptionPane.showMessageDialog(this, String.format(
+					"Encountered database value of '%s' for column [%s], which cannot be converted to a number.", getBoundColumnText(), getColumnForLog()));
 			logger.error(getColumnForLog() + ": Number Format Exception.", nfe);
 		}
 	}

--- a/swingset/src/main/java/com/nqadmin/swingset/SSComboBox.java
+++ b/swingset/src/main/java/com/nqadmin/swingset/SSComboBox.java
@@ -895,11 +895,7 @@ public class SSComboBox extends SSBaseComboBox<Integer, String, Object>
 			logger.debug("{}: targetValue - " + targetValue, () -> getColumnForLog());
 			
 			// UPDATE COMPONENT
-			if (targetValue==null) {
-				setSelectedItem(nullItem);
-			} else {
-				setSelectedMapping(targetValue);
-			}
+			setSelectedMapping(targetValue);// setSelectedMapping() should handle null OK.
 
 		} catch (final NumberFormatException nfe) {
 			JOptionPane.showMessageDialog(this, String.format(

--- a/swingset/src/main/java/com/nqadmin/swingset/SSDBComboBox.java
+++ b/swingset/src/main/java/com/nqadmin/swingset/SSDBComboBox.java
@@ -1649,11 +1649,7 @@ public class SSDBComboBox extends SSBaseComboBox<Long, Object, Object>
 			logger.debug("{}: targetValue - " + targetValue, () -> getColumnForLog());
 			
 			// UPDATE COMPONENT
-			if (targetValue==null) {
-				setSelectedItem(nullItem);
-			} else {
-				setSelectedMapping(targetValue);
-			}
+			setSelectedMapping(targetValue);// setSelectedMapping() should handle null OK.}
 
 		} catch (final NumberFormatException nfe) {
 			JOptionPane.showMessageDialog(this, String.format(

--- a/swingset/src/main/java/com/nqadmin/swingset/SSDBComboBox.java
+++ b/swingset/src/main/java/com/nqadmin/swingset/SSDBComboBox.java
@@ -1182,200 +1182,200 @@ public class SSDBComboBox extends SSBaseComboBox<Long, Object, Object>
 		firePropertyChange("secondDisplayColumnName", oldValue, secondDisplayColumnName);
 	}
 
-	/**
-	 * {@inheritDoc }
-	 * This method override additionally selects a currently edited item in the combo box
-	 */
-	@Override
-	public void setSelectedItem(final Object _value) {
-		logger.debug(() -> String.format("%s: setSelectedItem(%s), allowNull %b",
-				getColumnForLog(), _value, getAllowNull()));
-
-// TODO Need to deal with null on focus lost event. SSDBComboListener.actionPerformed setting bound column to  null when focus lost.
-
-// INTERCEPTING GLAZEDLISTS CALLS TO setSelectedItem() SO THAT WE CAN PREVENT IT FROM TRYING TO SET VALUES NOT IN THE LIST
-
-		// settingSelectedItem = true;
-
-		// try {
-
-// NOTE THAT CALLING setSelectedIndex(-1) IN THIS METHOD CAUSES  CYCLE HERE BECAUSE setSelectedIndex() CALLS setSelectedItem()
-
-//		logger.debug("{}: Selected Index BEFORE hidePopup()={}", () -> getColumnForLog(), () -> getSelectedIndex());
+//	/**
+//	 * {@inheritDoc }
+//	 * This method override additionally selects a currently edited item in the combo box
+//	 */
+//	@Override
+//	public void setSelectedItem(final Object _value) {
+//		logger.debug(() -> String.format("%s: setSelectedItem(%s), allowNull %b",
+//				getColumnForLog(), _value, getAllowNull()));
 //
-//		int possibleMatches = getItemCount();
-//		logger.debug("{}: Possible matches BEFORE hidePopup() - " + possibleMatches, () -> getColumnForLog());
+//// TODO Need to deal with null on focus lost event. SSDBComboListener.actionPerformed setting bound column to  null when focus lost.
 //
-//		//hidePopup();
+//// INTERCEPTING GLAZEDLISTS CALLS TO setSelectedItem() SO THAT WE CAN PREVENT IT FROM TRYING TO SET VALUES NOT IN THE LIST
 //
-//		possibleMatches = getItemCount();
-//		logger.debug("{}: Possible matches AFTER hidePopup() - " + possibleMatches, () -> getColumnForLog());
-//		logger.debug("{}: Selected Index AFTER hidePopup()={}", () -> getColumnForLog(), () -> getSelectedIndex());
-
-		// Call to super.setSelectedItem() triggers SSDBComboListener.actionPerformed, which calls getSelectedValue(), which calls getSelectedIndex(), which returns -1 while still in the editor
-		// and returns 0 after focus is lost.
-		//
-		// Calling hidePopup() restores the list, but messes up the GlazedList filtering.
-		//
-		// 2020-10-03_BP: Updated getSelectedValue() to properly return the primary key rather than using getSelectedIndex() during a call to this method.
-
-		// TODO: NOT SURE WHERE THE FOLLOWING COMMENT CAME FROM,
-		//       BUT THAT'S NOT HOW IT WORKS NOW
-		// Only try to update item for a valid list item.
-
-		Object newSelectedItem = _value;
-		if (newSelectedItem!=null) {
-			super.setSelectedItem(_value);
-			if (getEditor() != null && hasFocus()) {
-				// after we find a match, do a select all on the editor so
-				// if the user starts typing again it won't be appended
-				// 2020-12-21_BP: if we don't limited to field with focus, the comboboxes blink on navigation
-				// this also causes the focus to jump out of a navigation combo
-				getEditor().selectAll();
-			}
-			logger.debug("{}: Selected Index AFTER super.setSelectedItem()={}", () -> getColumnForLog(), () -> getSelectedIndex());
-		} else {
-			// Note that nullItem is null when allowNull is false.
-			// The next statement either selects null or the nullItem.
-			super.setSelectedItem(nullItem);
-			if (nullItem == null) {
-				logger.debug(() -> String.format("%s : Setting null when null not allowed. Current editor text is '%s'", getColumnForLog(), getEditor().getItem()));
-			}
-		}
-	}
-
-
-
-		// } finally {
-		// 	settingSelectedItem = false;
-		// 	selectedItem = null;
-		// }
-
-		//return;
-
-//		// DECLARATIONS
-//		String currentEditorText = "";
-//		int possibleMatches;
-//		SSListItem selectedItem;
+//		// settingSelectedItem = true;
 //
-//		// WE COULD BE HERE DUE TO:
-//		// 1. MOUSE CLICK ON AN ITEM
-//		// 2. KEYBASED NAVIGATION
-//		// 3. USER TYPING SEQUENTIALLY:
-//		// THIS MAY TRIGGER MATCHING ITEMS, OR MAY NOT MATCH ANY SUBSTRINGS SO WE DELETE
-//		// THE LAST CHARACTER
-//		// 4. USER DOING SOMETHING UNEXPECTED LIKE INSERTING CHARACTERS, DELETING ALL
-//		// TEXT, ETC.
-//		// THIS MAY TRIGGER MATCHING ITEMS, OR MAY NOT MATCH ANY SUBSTRINGS SO WE REVERT
-//		// TO THE LAST STRING AVAILABLE
-//		// IF NOT MATCH, COULD ALSO REVERT TO EMPTY STRING
+//		// try {
 //
-//		// GET LATEST TEXT TYPED BY USER
+//// NOTE THAT CALLING setSelectedIndex(-1) IN THIS METHOD CAUSES  CYCLE HERE BECAUSE setSelectedIndex() CALLS setSelectedItem()
 //
-//		if (getEditor().getItem() != null) {
-//			currentEditorText = getEditor().getItem().toString();
-//		}
+////		logger.debug("{}: Selected Index BEFORE hidePopup()={}", () -> getColumnForLog(), () -> getSelectedIndex());
+////
+////		int possibleMatches = getItemCount();
+////		logger.debug("{}: Possible matches BEFORE hidePopup() - " + possibleMatches, () -> getColumnForLog());
+////
+////		//hidePopup();
+////
+////		possibleMatches = getItemCount();
+////		logger.debug("{}: Possible matches AFTER hidePopup() - " + possibleMatches, () -> getColumnForLog());
+////		logger.debug("{}: Selected Index AFTER hidePopup()={}", () -> getColumnForLog(), () -> getSelectedIndex());
 //
-//		selectedItem = (SSListItem) _value;
+//		// Call to super.setSelectedItem() triggers SSDBComboListener.actionPerformed, which calls getSelectedValue(), which calls getSelectedIndex(), which returns -1 while still in the editor
+//		// and returns 0 after focus is lost.
+//		//
+//		// Calling hidePopup() restores the list, but messes up the GlazedList filtering.
+//		//
+//		// 2020-10-03_BP: Updated getSelectedValue() to properly return the primary key rather than using getSelectedIndex() during a call to this method.
 //
-//		// FOUR OUTCOMES:
-//		// 1. _value is null, but selectedItem is not null, indicating a match (so null
-//		// is a valid choice)
-//		// 2. _value is null and selectedItem is null, indicating no match
-//		// 3. neither _value nor selectedItem are null, indicating a match
-//		// 4. _value is not null, but selectedItem is null, indicating no match (have to
-//		// revert text)
+//		// TODO: NOT SURE WHERE THE FOLLOWING COMMENT CAME FROM,
+//		//       BUT THAT'S NOT HOW IT WORKS NOW
+//		// Only try to update item for a valid list item.
 //
-//		if (selectedItem != null) {
-//			// OUTCOME 1 & 3 ABOVE, MAKE CALL TO SUPER AND MOVE ALONG
-//			// Display contents of selectedItem for debugging
-//			logger.debug("{}: PK={}, Item={}.", () -> getColumnForLog(), () -> selectedItem.getPrimaryKey(), () -> selectedItem.getListItem());
-//			logger.debug("{}: Prior text was '" + priorEditorText + "'. Current text is '" + currentEditorText + "'.", () -> getColumnForLog());
-//
-//			// We have to be VERY careful with calls to setSelectedItem() because it will
-//			// set the value based on the index of any SUBSET list returned by GlazedList,
-//			// not the full list
-//			//
-//			// Calling hidePopup() clears the subset list so that the subsequent
-//			// call to setSelectedItem works as intended.
-//
-//			possibleMatches = getItemCount();
-//			logger.debug("{}: Possible matches BEFORE hidePopup() - " + possibleMatches, () -> getColumnForLog());
-//
-//			hidePopup();
-//
-//			possibleMatches = getItemCount();
-//			logger.debug("{}: Possible matches AFTER hidePopup() - " + possibleMatches, () -> getColumnForLog());
-//
-//			// Call to parent method.
-//			// Don't call setSelectedIndex() as this causes a cycle
-//			// setSelectedIndex()->setSelectedItem().
-//			logger.debug("{}: Calling super.setSelectedItem(" + selectedItem + ")", () -> getColumnForLog());
-//			super.setSelectedItem(selectedItem);
-//
-//			// Update editor text
-//			currentEditorText = selectedItem.getListItem();
-//			getEditor().setItem(currentEditorText);
-//			updateUI();
-//
-//			logger.debug("{}: Prior text was '" + priorEditorText + "'. Current text is '" + currentEditorText + "'.", () -> getColumnForLog());
-//
-//			// update priorEditorText
-//			priorEditorText = currentEditorText;
-//
-//		} else if (_value == null) {
-//			// OUTCOME 2 ABOVE
-//			// setSelectedItem() was called with null, but there is no match (so null is not a valid selection in the list)
-//			// There may be partial matches from GlazedList.
-//			logger.debug("{}: Method called with null. Prior text was '" + priorEditorText + "'. Current text is '" + currentEditorText + "'.", () -> getColumnForLog());
-//
-//			// Determine if there are partial matches on the popup list due to user typing.
-//			possibleMatches = getItemCount();
-//			logger.debug("{}: Possible matches - " + possibleMatches, () -> getColumnForLog());
-//
-//			if (possibleMatches > 0) {
-//				// update the latestTypedText, but don't make a call to super.setSelectedItem(). No change to bound value.
-//				priorEditorText = currentEditorText;
-//			} else {
-//// 2020-08-03: if user types "x" and it is not a choice we land here
-//// on call to updateUI(), focus is lost and list items revert to 6 for "ss_db_combo_box" column in swingset_tests.sql
-//// if "x" is typed a 2nd time, the popup does not become visible again and there are zero items in the list before and after the call
-//// to setItem() and/or to updateUI()
-//
-//
-//// This could also be the result of the first call to execute() where nothing has been typed and the popup is not visible.
-//// This will throw a 'java.awt.IllegalComponentStateException' exception when showPopup() is called.
-//				//if (!this.isVisible()) {
-//				if (currentEditorText.isEmpty()) {
-//					logger.debug("{}: Method called with null, but nothing has been typed. This occurs during screen initialization.", () -> getColumnForLog());
-//					super.setSelectedItem(selectedItem);
-//					// 2020-10-03_BP: Probably need to update priorEditorText here
-//					priorEditorText = currentEditorText;
-//				} else {
-//					logger.debug("{}: Reverting to prior typed text.", () -> getColumnForLog());
-//					getEditor().setItem(priorEditorText);
-//					// IMPORTANT: The particular order here of showPopup() and then updateUI() seems to restore the
-//					// underlying GlazedList to all of the items. Reversing this order breaks things. Calling hidePopup() does not work.
-//					showPopup();
-//					updateUI(); // This refreshes the characters displayed. Display does not update without call to updateUI();
-//								// updateUI() triggers focus lost
-//					possibleMatches = getItemCount();
-//
-//					logger.debug("{}: Possible matches AFTER reverting text - " + possibleMatches, () -> getColumnForLog());
-//				}
+//		Object newSelectedItem = _value;
+//		if (newSelectedItem!=null) {
+//			super.setSelectedItem(_value);
+//			if (getEditor() != null && hasFocus()) {
+//				// after we find a match, do a select all on the editor so
+//				// if the user starts typing again it won't be appended
+//				// 2020-12-21_BP: if we don't limited to field with focus, the comboboxes blink on navigation
+//				// this also causes the focus to jump out of a navigation combo
+//				getEditor().selectAll();
 //			}
-//
+//			logger.debug("{}: Selected Index AFTER super.setSelectedItem()={}", () -> getColumnForLog(), () -> getSelectedIndex());
 //		} else {
-//			// OUTCOME 4 ABOVE
-//			// generally not expecting this outcome
-//			// revert to prior string and don't select anything
-//			logger.warn(getColumnForLog() + ": Method called with " + _value + ", but there is no match. Prior text was '" + priorEditorText + "'. Current text is '" + currentEditorText + "'.");
-//
-//			// TODO Throw an exception here? May be the result of a coding error.
-//			getEditor().setItem(priorEditorText);
-//			currentEditorText = priorEditorText;
-//			updateUI(); // This refreshes the characters displayed.
+//			// Note that nullItem is null when allowNull is false.
+//			// The next statement either selects null or the nullItem.
+//			super.setSelectedItem(nullItem);
+//			if (nullItem == null) {
+//				logger.debug(() -> String.format("%s : Setting null when null not allowed. Current editor text is '%s'", getColumnForLog(), getEditor().getItem()));
+//			}
 //		}
+//	}
+//
+//
+//
+//		// } finally {
+//		// 	settingSelectedItem = false;
+//		// 	selectedItem = null;
+//		// }
+//
+//		//return;
+//
+////		// DECLARATIONS
+////		String currentEditorText = "";
+////		int possibleMatches;
+////		SSListItem selectedItem;
+////
+////		// WE COULD BE HERE DUE TO:
+////		// 1. MOUSE CLICK ON AN ITEM
+////		// 2. KEYBASED NAVIGATION
+////		// 3. USER TYPING SEQUENTIALLY:
+////		// THIS MAY TRIGGER MATCHING ITEMS, OR MAY NOT MATCH ANY SUBSTRINGS SO WE DELETE
+////		// THE LAST CHARACTER
+////		// 4. USER DOING SOMETHING UNEXPECTED LIKE INSERTING CHARACTERS, DELETING ALL
+////		// TEXT, ETC.
+////		// THIS MAY TRIGGER MATCHING ITEMS, OR MAY NOT MATCH ANY SUBSTRINGS SO WE REVERT
+////		// TO THE LAST STRING AVAILABLE
+////		// IF NOT MATCH, COULD ALSO REVERT TO EMPTY STRING
+////
+////		// GET LATEST TEXT TYPED BY USER
+////
+////		if (getEditor().getItem() != null) {
+////			currentEditorText = getEditor().getItem().toString();
+////		}
+////
+////		selectedItem = (SSListItem) _value;
+////
+////		// FOUR OUTCOMES:
+////		// 1. _value is null, but selectedItem is not null, indicating a match (so null
+////		// is a valid choice)
+////		// 2. _value is null and selectedItem is null, indicating no match
+////		// 3. neither _value nor selectedItem are null, indicating a match
+////		// 4. _value is not null, but selectedItem is null, indicating no match (have to
+////		// revert text)
+////
+////		if (selectedItem != null) {
+////			// OUTCOME 1 & 3 ABOVE, MAKE CALL TO SUPER AND MOVE ALONG
+////			// Display contents of selectedItem for debugging
+////			logger.debug("{}: PK={}, Item={}.", () -> getColumnForLog(), () -> selectedItem.getPrimaryKey(), () -> selectedItem.getListItem());
+////			logger.debug("{}: Prior text was '" + priorEditorText + "'. Current text is '" + currentEditorText + "'.", () -> getColumnForLog());
+////
+////			// We have to be VERY careful with calls to setSelectedItem() because it will
+////			// set the value based on the index of any SUBSET list returned by GlazedList,
+////			// not the full list
+////			//
+////			// Calling hidePopup() clears the subset list so that the subsequent
+////			// call to setSelectedItem works as intended.
+////
+////			possibleMatches = getItemCount();
+////			logger.debug("{}: Possible matches BEFORE hidePopup() - " + possibleMatches, () -> getColumnForLog());
+////
+////			hidePopup();
+////
+////			possibleMatches = getItemCount();
+////			logger.debug("{}: Possible matches AFTER hidePopup() - " + possibleMatches, () -> getColumnForLog());
+////
+////			// Call to parent method.
+////			// Don't call setSelectedIndex() as this causes a cycle
+////			// setSelectedIndex()->setSelectedItem().
+////			logger.debug("{}: Calling super.setSelectedItem(" + selectedItem + ")", () -> getColumnForLog());
+////			super.setSelectedItem(selectedItem);
+////
+////			// Update editor text
+////			currentEditorText = selectedItem.getListItem();
+////			getEditor().setItem(currentEditorText);
+////			updateUI();
+////
+////			logger.debug("{}: Prior text was '" + priorEditorText + "'. Current text is '" + currentEditorText + "'.", () -> getColumnForLog());
+////
+////			// update priorEditorText
+////			priorEditorText = currentEditorText;
+////
+////		} else if (_value == null) {
+////			// OUTCOME 2 ABOVE
+////			// setSelectedItem() was called with null, but there is no match (so null is not a valid selection in the list)
+////			// There may be partial matches from GlazedList.
+////			logger.debug("{}: Method called with null. Prior text was '" + priorEditorText + "'. Current text is '" + currentEditorText + "'.", () -> getColumnForLog());
+////
+////			// Determine if there are partial matches on the popup list due to user typing.
+////			possibleMatches = getItemCount();
+////			logger.debug("{}: Possible matches - " + possibleMatches, () -> getColumnForLog());
+////
+////			if (possibleMatches > 0) {
+////				// update the latestTypedText, but don't make a call to super.setSelectedItem(). No change to bound value.
+////				priorEditorText = currentEditorText;
+////			} else {
+////// 2020-08-03: if user types "x" and it is not a choice we land here
+////// on call to updateUI(), focus is lost and list items revert to 6 for "ss_db_combo_box" column in swingset_tests.sql
+////// if "x" is typed a 2nd time, the popup does not become visible again and there are zero items in the list before and after the call
+////// to setItem() and/or to updateUI()
+////
+////
+////// This could also be the result of the first call to execute() where nothing has been typed and the popup is not visible.
+////// This will throw a 'java.awt.IllegalComponentStateException' exception when showPopup() is called.
+////				//if (!this.isVisible()) {
+////				if (currentEditorText.isEmpty()) {
+////					logger.debug("{}: Method called with null, but nothing has been typed. This occurs during screen initialization.", () -> getColumnForLog());
+////					super.setSelectedItem(selectedItem);
+////					// 2020-10-03_BP: Probably need to update priorEditorText here
+////					priorEditorText = currentEditorText;
+////				} else {
+////					logger.debug("{}: Reverting to prior typed text.", () -> getColumnForLog());
+////					getEditor().setItem(priorEditorText);
+////					// IMPORTANT: The particular order here of showPopup() and then updateUI() seems to restore the
+////					// underlying GlazedList to all of the items. Reversing this order breaks things. Calling hidePopup() does not work.
+////					showPopup();
+////					updateUI(); // This refreshes the characters displayed. Display does not update without call to updateUI();
+////								// updateUI() triggers focus lost
+////					possibleMatches = getItemCount();
+////
+////					logger.debug("{}: Possible matches AFTER reverting text - " + possibleMatches, () -> getColumnForLog());
+////				}
+////			}
+////
+////		} else {
+////			// OUTCOME 4 ABOVE
+////			// generally not expecting this outcome
+////			// revert to prior string and don't select anything
+////			logger.warn(getColumnForLog() + ": Method called with " + _value + ", but there is no match. Prior text was '" + priorEditorText + "'. Current text is '" + currentEditorText + "'.");
+////
+////			// TODO Throw an exception here? May be the result of a coding error.
+////			getEditor().setItem(priorEditorText);
+////			currentEditorText = priorEditorText;
+////			updateUI(); // This refreshes the characters displayed.
+////		}
 
 	/**
 	 * {@inheritDoc }

--- a/swingset/src/main/java/com/nqadmin/swingset/SSDBComboBox.java
+++ b/swingset/src/main/java/com/nqadmin/swingset/SSDBComboBox.java
@@ -1532,6 +1532,88 @@ public class SSDBComboBox extends SSBaseComboBox<Long, Object, Object>
 //		return result;
 	}
 
+//	/**
+//	 * Updates the value stored and displayed in the SwingSet component based on
+//	 * getBoundColumnText()
+//	 * <p>
+//	 * Call to this method should be coming from SSCommon and should already have
+//	 * the Component listener removed
+//	 */
+//	@Override
+//	public void updateSSComponent() {
+//		// TODO Modify this class similar to updateSSComponent() in SSFormattedTextField and only allow JDBC types that convert to Long or Integer
+//		try {
+//			// 2020-10-05_BP: If initialization is taking place then there won't be any mappings so don't try to update anything yet.
+//
+//			// TODO: how does this happen?
+//			//if (eventList==null) {
+//			//	return;
+//			//}
+//			if (!hasItems()) {
+//				return;
+//			}
+//
+//			// If the user was on this component and the GlazedList had a subset of items, then
+//			// navigating resulting in a call to updateSSComponent()->setSelectedValue() may try to do a lookup based on
+//			// the GlazedList subset and generate:
+//			// Exception in thread "AWT-EventQueue-0" java.lang.IllegalArgumentException: setSelectedIndex: X out of bounds
+//			//int possibleMatches = getItemCount();
+//			//logger.debug("{}: Possible matches BEFORE setPopupVisible(false): " + possibleMatches, () -> getColumnForLog());
+//
+//			//this.setPopupVisible(false);
+//			//updateUI();
+//
+//			//possibleMatches = getItemCount();
+//			//logger.debug("{}: Possible matches AFTER setPopupVisible(false): " + possibleMatches, () -> getColumnForLog());
+//
+//			// THIS SHOULD BE CALLED AS A RESULT OF SOME ACTION ON THE ROWSET SO RESET THE EDITOR STRINGS BEFORE DOING ANYTHING ELSE
+//			// This is going to make a little noise in the debug logs since it results in an "extra" call to setSelectedItem()
+//			getEditor().setItem("");
+//
+//
+//			// Combobox primary key column data queried from the database will generally be of data type long.
+//			// The bound column text should generally be a long integer as well, but trimming to be safe.
+//			// TODO Consider starting with a Long and passing directly to setSelectedValue(primaryKey). Modify setSelectedValue to accept a Long vs long.
+//			final String text = getBoundColumnText();
+//
+//			logger.trace("{}: getBoundColumnText() - " + text, () -> getColumnForLog());
+//
+//			// GET THE BOUND VALUE STORED IN THE ROWSET
+//			//if (text != null && !(text.equals(""))) {
+//			if ((text != null) && !text.isEmpty()) {
+//
+//				final long primaryKey = Long.parseLong(text);
+//
+//				logger.debug("{}: Calling setSelectedValue(" + primaryKey + ").", () -> getColumnForLog());
+//
+//				setSelectedValue(primaryKey);
+//
+//			} else {
+//				logger.debug("{}: Calling setSelectedIndex(-1).", () -> getColumnForLog());
+//
+//				setSelectedIndex(-1);
+//				//updateUI();
+//			}
+//
+//			// TODO Consider commenting this out for performance.
+//			//String editorString = null;
+//			//if (getEditor().getItem() != null) {
+//			//	editorString = getEditor().getItem().toString();
+//			//}
+//			//logger.debug("{}: Combo editor string: " + editorString, () -> getColumnForLog());
+//			logger.trace(() -> {
+//				String editorString = null;
+//				if (getEditor().getItem() != null) {
+//					editorString = getEditor().getItem().toString();
+//				}
+//				return getColumnForLog() + ": Combo editor string: " + editorString;
+//			});
+//
+//		} catch (final NumberFormatException nfe) {
+//			logger.error(getColumnForLog() + ": Number Format Exception.", nfe);
+//		}
+//	}
+	
 	/**
 	 * Updates the value stored and displayed in the SwingSet component based on
 	 * getBoundColumnText()
@@ -1541,73 +1623,35 @@ public class SSDBComboBox extends SSBaseComboBox<Long, Object, Object>
 	 */
 	@Override
 	public void updateSSComponent() {
-		// TODO Modify this class similar to updateSSComponent() in SSFormattedTextField and only allow JDBC types that convert to Long or Integer
+		// TODO Modify this class similar to updateSSComponent() in SSFormattedTextField and only limit JDBC types accepted
 		try {
-			// 2020-10-05_BP: If initialization is taking place then there won't be any mappings so don't try to update anything yet.
-
-			// TODO: how does this happen?
-			//if (eventList==null) {
-			//	return;
-			//}
+			// If initialization is taking place then there won't be any mappings so don't try to update anything yet.
 			if (!hasItems()) {
 				return;
 			}
 
-			// If the user was on this component and the GlazedList had a subset of items, then
-			// navigating resulting in a call to updateSSComponent()->setSelectedValue() may try to do a lookup based on
-			// the GlazedList subset and generate:
-			// Exception in thread "AWT-EventQueue-0" java.lang.IllegalArgumentException: setSelectedIndex: X out of bounds
-			//int possibleMatches = getItemCount();
-			//logger.debug("{}: Possible matches BEFORE setPopupVisible(false): " + possibleMatches, () -> getColumnForLog());
+			// SSDBComboBox will generally work with primary key column data queried from the database, which will generally be of data type long.
+			// SSComboBox is generally used with 2 or 4 byte integer columns.
+			final String boundColumnText = getBoundColumnText();
 
-			//this.setPopupVisible(false);
-			//updateUI();
+			// LOGGING
+			logger.debug("{}: getBoundColumnText() - " + boundColumnText, () -> getColumnForLog());
 
-			//possibleMatches = getItemCount();
-			//logger.debug("{}: Possible matches AFTER setPopupVisible(false): " + possibleMatches, () -> getColumnForLog());
-
-			// THIS SHOULD BE CALLED AS A RESULT OF SOME ACTION ON THE ROWSET SO RESET THE EDITOR STRINGS BEFORE DOING ANYTHING ELSE
-			// This is going to make a little noise in the debug logs since it results in an "extra" call to setSelectedItem()
-			getEditor().setItem("");
-
-
-			// Combobox primary key column data queried from the database will generally be of data type long.
-			// The bound column text should generally be a long integer as well, but trimming to be safe.
-			// TODO Consider starting with a Long and passing directly to setSelectedValue(primaryKey). Modify setSelectedValue to accept a Long vs long.
-			final String text = getBoundColumnText();
-
-			logger.trace("{}: getBoundColumnText() - " + text, () -> getColumnForLog());
-
-			// GET THE BOUND VALUE STORED IN THE ROWSET
-			//if (text != null && !(text.equals(""))) {
-			if ((text != null) && !text.isEmpty()) {
-
-				final long primaryKey = Long.parseLong(text);
-
-				logger.debug("{}: Calling setSelectedValue(" + primaryKey + ").", () -> getColumnForLog());
-
-				setSelectedValue(primaryKey);
-
-			} else {
-				logger.debug("{}: Calling setSelectedIndex(-1).", () -> getColumnForLog());
-
-				setSelectedIndex(-1);
-				//updateUI();
+			// GET THE BOUND VALUE STORED IN THE ROWSET - may throw a NumberFormatException
+			Long targetValue = null;
+			if ((boundColumnText != null) && !boundColumnText.isEmpty()) {
+				targetValue = Long.parseLong(boundColumnText);
 			}
-
-			// TODO Consider commenting this out for performance.
-			//String editorString = null;
-			//if (getEditor().getItem() != null) {
-			//	editorString = getEditor().getItem().toString();
-			//}
-			//logger.debug("{}: Combo editor string: " + editorString, () -> getColumnForLog());
-			logger.trace(() -> {
-				String editorString = null;
-				if (getEditor().getItem() != null) {
-					editorString = getEditor().getItem().toString();
-				}
-				return getColumnForLog() + ": Combo editor string: " + editorString;
-			});
+			
+			// LOGGING
+			logger.debug("{}: targetValue - " + targetValue, () -> getColumnForLog());
+			
+			// UPDATE COMPONENT
+			if (targetValue==null) {
+				setSelectedItem(nullItem);
+			} else {
+				setSelectedMapping(targetValue);
+			}
 
 		} catch (final NumberFormatException nfe) {
 			logger.error(getColumnForLog() + ": Number Format Exception.", nfe);

--- a/swingset/src/main/java/com/nqadmin/swingset/SSDBComboBox.java
+++ b/swingset/src/main/java/com/nqadmin/swingset/SSDBComboBox.java
@@ -44,6 +44,8 @@ import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.swing.JOptionPane;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -1654,6 +1656,8 @@ public class SSDBComboBox extends SSBaseComboBox<Long, Object, Object>
 			}
 
 		} catch (final NumberFormatException nfe) {
+			JOptionPane.showMessageDialog(this, String.format(
+					"Encountered database value of '%s' for column [%s], which cannot be converted to a number.", getBoundColumnText(), getColumnForLog()));
 			logger.error(getColumnForLog() + ": Number Format Exception.", nfe);
 		}
 	}

--- a/swingset/src/main/java/com/nqadmin/swingset/utils/SSSyncManager.java
+++ b/swingset/src/main/java/com/nqadmin/swingset/utils/SSSyncManager.java
@@ -75,6 +75,9 @@ public class SSSyncManager {
 		
 		private int actionPerformedCount = 0;
 		
+		// **** GL STRICT/CONTAINS ****
+		//
+		// Hopefully lastValidItem can be eliminated once GlazedLists fully supports STRICT/CONTAINS
 		private SSListItem lastValidItem = null;
 
 		private Long comboPK;
@@ -96,10 +99,12 @@ public class SSSyncManager {
 				comboPK = comboBox.getSelectedMapping();
 				logger.debug("COMBO NAVIGATOR: getSelectedMapping() returned: {}.", () -> comboPK);
 				
-				// getSelectedMapping() could return null during initialization or 
-				// If using UP/DOWN arrows with a GlazedList and you above first item or below last item. Note that this should
-				// not happen now that glazedListArrowHandler() has been added to SSBaseComboBox.
+				// getSelectedMapping() could return null during initialization.
+				// We check for null/empty rowset in the prior block.
 				if (comboPK==null) {
+					// **** GL STRICT/CONTAINS ****
+					//
+					// Hopefully lastValidItem can be eliminated once GlazedLists fully supports STRICT/CONTAINS
 					if (lastValidItem!=null) {
 					// WE GET A NULL PK WHEN THE USER CLEARS THE COMBO EDITOR. NORMALLY lastValidItem WILL BE THE VERY FIRST RECORD IF THIS HAPPENS.
 						comboBox.setSelectedItem(lastValidItem); 
@@ -107,15 +112,18 @@ public class SSSyncManager {
 					return;
 				}
 				
-				// EXTRACT SELECTED ITEM
-				Object selectedItem = comboBox.getSelectedItem();
-					
-				// THIS SHOULD ALWAYS BE A SSLISTITEM, BUT COULD BE SOME EDGE CASES?
-				if (selectedItem instanceof SSListItem) {
-					lastValidItem = (SSListItem)selectedItem;
-				} else {
-					logger.warn(" -- Selected Item is not a SSListItem.");
-				}
+				// **** GL STRICT/CONTAINS ****
+				//
+				// Hopefully selectedItem and lastValidItem can be eliminated once GlazedLists fully supports STRICT/CONTAINS
+					// EXTRACT AND STORE SELECTED ITEM
+					Object selectedItem = comboBox.getSelectedItem();
+						
+					// THIS SHOULD ALWAYS BE A SSLISTITEM, BUT COULD BE SOME EDGE CASES?
+					if (selectedItem instanceof SSListItem) {
+						lastValidItem = (SSListItem)selectedItem;
+					} else {
+						logger.warn(" -- Selected Item is not a SSListItem.");
+					}
 
 				// UPDATE THE PRESENT ROW BEFORE MOVING TO ANOTHER ROW.
 				// This code was removed to improve performance.


### PR DESCRIPTION
Completely off track from the original branch intent (Issue #38). Was hoping to switch from action/item listeners to focus listeners, but as cited here: https://stackoverflow.com/questions/10293135/jcombobox-focuslost-is-not-firing-why-is-that
 the focus listener is very difficult to deal with for combos. This lead me to abandon focus listeners and try to fix the action listeners to better deal with:
1. Glazed List issue #37 
2. "garbage" strings entered by user
3. clearing of the combo by the user (e.g., backspace to clear any text in the combo)
I spent a lot of time trying to auto-revert strings if a CONTAINS matched on a GlazedList resulted in zero items (e.g. "ScreX"). 

At one time (months ago?) the combination of:
```
getEditor().setItem(priorEditorText);
showPopup();
updateUI();
```
seemed to work, but I could not get it to take. The behavior is what I would expect if isEditable()==false, but GL supposedly forces combos to be editable, and I confirmed that isEditable() returned true inside of setSelectedItem().