### PR TITLE
By default, no OptionMappingSwingModel list locking, re-use Remodel.

### DIFF
--- a/swingset/src/main/java/com/nqadmin/swingset/SSBaseComboBox.java
+++ b/swingset/src/main/java/com/nqadmin/swingset/SSBaseComboBox.java
@@ -66,6 +66,9 @@ import ca.odell.glazedlists.BasicEventList;
 import ca.odell.glazedlists.matchers.TextMatcherEditor;
 import ca.odell.glazedlists.swing.AutoCompleteSupport;
 
+import static com.nqadmin.swingset.models.AbstractComboBoxListSwingModel.addEventLogging;
+import static com.nqadmin.swingset.models.OptionMappingSwingModel.asOptionMappingSwingModel;
+
 // SSBaseComboBox.java
 //
 // SwingSet - Open Toolkit For Making Swing Controls Database-Aware
@@ -147,7 +150,6 @@ public abstract class SSBaseComboBox<M,O,O2> extends JComboBox<SSListItem> imple
 	 */
 	protected static class BaseModel<M,O,O2> extends OptionMappingSwingModel<M,O,O2>
 	{
-		private static final long serialVersionUID = 1L;
 
 		/**
 		 * Create model and install it in the specified JComboBox.
@@ -182,7 +184,6 @@ public abstract class SSBaseComboBox<M,O,O2> extends JComboBox<SSListItem> imple
 	 */
 	protected static class BaseGlazedModel<M,O,O2> extends GlazedListsOptionMappingInfo<M,O,O2>
 	{
-		private static final long serialVersionUID = 1L;
 
 		/**
 		 * The GlazedLists auto completion support for the
@@ -271,12 +272,14 @@ public abstract class SSBaseComboBox<M,O,O2> extends JComboBox<SSListItem> imple
 	// TODO: throw exception?
 	@Override
 	@SuppressWarnings("unchecked")
-	public void setModel(ComboBoxModel<SSListItem> model) {
+	public void setModel(ComboBoxModel<SSListItem> _model) {
+		addEventLogging(_model);
+		OptionMappingSwingModel<?, ?, ?> model = asOptionMappingSwingModel(_model);
 		optionModel = model instanceof BaseModel ? (BaseModel<M,O,O2>)model
 				: model instanceof BaseGlazedModel ? (BaseGlazedModel<M,O,O2>)model
 				: null;
 
-		super.setModel(model);
+		super.setModel(_model);
 	}
 
 	/**

--- a/swingset/src/main/java/com/nqadmin/swingset/SSDBComboBox.java
+++ b/swingset/src/main/java/com/nqadmin/swingset/SSDBComboBox.java
@@ -645,7 +645,8 @@ public class SSDBComboBox extends SSBaseComboBox<Long, Object, Object>
 		
 		// int result = 0;
 
-		return optionModel.getSize();
+		//return optionModel.getSize();
+		return optionModel.getItemList().size();
 
 		// if (eventList != null) {
 		// 	result = eventList.size();

--- a/swingset/src/main/java/com/nqadmin/swingset/SSList.java
+++ b/swingset/src/main/java/com/nqadmin/swingset/SSList.java
@@ -66,6 +66,8 @@ import com.nqadmin.swingset.models.SSCollectionModel;
 import com.nqadmin.swingset.models.SSDbArrayModel;
 import com.nqadmin.swingset.models.SSListItem;
 
+import static com.nqadmin.swingset.models.OptionMappingSwingModel.asOptionMappingSwingModel;
+
 // SSList.java
 //
 // SwingSet - Open Toolkit For Making Swing Controls Database-Aware
@@ -341,11 +343,16 @@ public class SSList extends JList<SSListItem> implements SSComponentInterface {
 		removeListSelectionListener(ssListListener);
 	}
 
+	/**
+	 * {@inheritDoc}
+	 * Set up OptionMappingSwingModel if parameter matches.
+	 */
 	@Override
-	public void setModel(ListModel<SSListItem> model) {
+	public void setModel(ListModel<SSListItem> _model) {
+		OptionMappingSwingModel<?, ?, ?> model = asOptionMappingSwingModel(_model);
 		optionSwingModel = model instanceof Model ? (Model)model : null;
 
-		super.setModel(model);
+		super.setModel(_model);
 	}
 
 	/**

--- a/swingset/src/main/java/com/nqadmin/swingset/models/GlazedListsOptionMappingInfo.java
+++ b/swingset/src/main/java/com/nqadmin/swingset/models/GlazedListsOptionMappingInfo.java
@@ -58,7 +58,7 @@ import ca.odell.glazedlists.EventList;
  */
 public class GlazedListsOptionMappingInfo<M,O,O2> extends OptionMappingSwingModel<M,O,O2> {
 	private static final long serialVersionUID = 1L;
-	private EventList<SSListItem> eventList;
+	private final EventList<SSListItem> eventList;
 	private boolean hasReturnedEventList;
 
 	/**
@@ -104,29 +104,26 @@ public class GlazedListsOptionMappingInfo<M,O,O2> extends OptionMappingSwingMode
 	public Remodel getRemodel() {
 		return new Remodel();
 	}
-
+	
 	/**
-	 * Remodel that locks the GlazedLists EventList.
+	 * This is called during Remodel construction,
+	 * take the EventList's write lock.
 	 */
-	public class Remodel extends OptionMappingSwingModel<M, O, O2>.Remodel implements AutoCloseable {
-
-		/**
-		 * This is called during construction,
-		 * take the EventList's write lock.
-		 */
-		@Override
-		protected void takeWriteLock() {
-			eventList.getReadWriteLock().writeLock().lock();
-		}
-
-		/**
-		 * This is called during close,
-		 * release the EventList's write lock.
-		 */
-		@Override
-		protected void releaseWriteLock() {
-			eventList.getReadWriteLock().writeLock().unlock();
-		}
+	@Override
+	protected void remodelTakeWriteLock() {
+		eventList.getReadWriteLock().writeLock().lock();
+	}
+	
+	/**
+	 * This is called during Remodel close,
+	 * release the EventList's write lock.
+	 * NOTE: {@code remodel.isClosed = true} prevents re-use of the remodel.
+	 * @param remodel base remodel
+	 */
+	@Override
+	protected void remodelReleaseWriteLock(AbstractComboBoxListSwingModel.Remodel remodel) {
+		eventList.getReadWriteLock().writeLock().unlock();
+		remodel.isClosed = true;
 	}
 	
 }

--- a/swingset/src/main/java/com/nqadmin/swingset/models/OptionMappingSwingModel.java
+++ b/swingset/src/main/java/com/nqadmin/swingset/models/OptionMappingSwingModel.java
@@ -42,6 +42,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
+import javax.swing.ListModel;
+
 
 // OptionMappingSwingModel.java
 //
@@ -72,7 +74,6 @@ import java.util.Objects;
  * @since 4.0.0
  */
 public class OptionMappingSwingModel<M,O,O2> extends AbstractComboBoxListSwingModel {
-	private static final long serialVersionUID = 1L;
 
 	/** index of option in SSListItem */
 	// Option IS FIRST. THIS IS THE DEFAULT FOR SSListItemFormat
@@ -88,6 +89,26 @@ public class OptionMappingSwingModel<M,O,O2> extends AbstractComboBoxListSwingMo
 	private final List<?>[] slices = new List<?>[3];
 	/** when true, there can be options2 */
 	private boolean option2Enabled = false;
+
+	/**
+	 * Given some model, if possible return the model
+	 * cast as a OptionMappingSwingModel.
+	 * @param _model model to check
+	 * @return OptionMappingSwingModel or null
+	 */
+	public static OptionMappingSwingModel<?,?,?> asOptionMappingSwingModel(ListModel<SSListItem> _model) {
+
+		if (_model instanceof OptionMappingSwingModel) {
+			return (OptionMappingSwingModel) _model;
+		}
+		if (_model instanceof ComboBoxListSwingModel) {
+			Object model = ((ComboBoxListSwingModel)_model).getComboBoxListSwingModel();
+			if (model instanceof OptionMappingSwingModel) {
+				return (OptionMappingSwingModel) model;
+			}
+		}
+		return null;
+	}
 
 	/**
 	 * Create an empty OptionMappingSwingModel .
@@ -280,17 +301,22 @@ public class OptionMappingSwingModel<M,O,O2> extends AbstractComboBoxListSwingMo
 	 */
 	@Override
 	public Remodel getRemodel() {
-		return new Remodel();
+		// default is no locking, re-use the model.
+		if (remodel == null) {
+			remodel = new Remodel();
+		}
+		return remodel;
 	}
-
+	private Remodel remodel;
+	
+	// no locking by default
+	/** {@inheritDoc} */
+	@Override protected void remodelTakeWriteLock() { }
+	/** {@inheritDoc} */
+	@Override protected void remodelReleaseWriteLock(AbstractComboBoxListSwingModel.Remodel remodel) { }
+	
 	/** Methods for inspecting and modifying list info */
 	public class Remodel extends AbstractComboBoxListSwingModel.Remodel {
-
-		// no locking by default
-		/** {@inheritDoc} */
-		@Override protected void takeWriteLock() { }
-		/** {@inheritDoc} */
-		@Override protected void releaseWriteLock() { }
 		
 		/**
 		 * Return an unmodifiable list of mappings.

--- a/swingset/src/main/java/com/nqadmin/swingset/utils/SSUtils.java
+++ b/swingset/src/main/java/com/nqadmin/swingset/utils/SSUtils.java
@@ -1,0 +1,96 @@
+/* *****************************************************************************
+ * Copyright (C) 2021, Prasanth R. Pasala, Brian E. Pangburn, & The Pangburn Group
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Contributors:
+ *   Prasanth R. Pasala
+ *   Brian E. Pangburn
+ *   Diego Gil
+ *   Man "Bee" Vo
+ *   Ernie R. Rael
+ * ****************************************************************************/
+package com.nqadmin.swingset.utils;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ *
+ * @author err
+ */
+public class SSUtils {
+	private SSUtils() {}
+
+	//private static final Logger logger = LogManager.getLogger();
+
+	/**
+	 * Returns an unmodifiable list containing an arbitrary number of elements.
+	 * This is not particularly efficient for small lists, but until java-9...
+	 * @param <T> type of elements in the list
+	 * @param args the elements of the list
+	 * @return list
+	 */
+	@SafeVarargs
+	static <T> List<T> listOf(T... args) {
+		Object[] arr = Arrays.copyOf(args, args.length);
+		@SuppressWarnings("unchecked")
+		List<T> list = (List<T>) Collections.unmodifiableList(Arrays.asList(arr));
+		return list;
+	}
+	////////////////////////////////////////////////////////////////////////////
+	//
+	// Debug Support
+	//
+
+	/**
+	 * Return a unique name for an Object, for example "String@89AB".
+	 * Name is SimpleClassName followed by identityHashCode in hex.
+	 * Used primarily for debug messages.
+	 * @param o The Object
+	 * @return unique name for the object or "null"
+	 */
+	// TODO: put this in utils/SSUtil
+	public static String objectID(Object o) {
+		if (o == null) {
+			return "null";
+		}
+		return String.format("%s@%X", o.getClass().getSimpleName(), System.identityHashCode(o));
+	}
+
+	////////////////////////////////////////////////////////////////////////////
+	//
+	// EventBus
+	//
+	//     posting Events
+	//     finding a bus
+	//
+	// TODO:
+
+}

--- a/swingset/src/test/java/com/nqadmin/swingset/models/AbstractComboBoxListSwingModelTest.java
+++ b/swingset/src/test/java/com/nqadmin/swingset/models/AbstractComboBoxListSwingModelTest.java
@@ -55,18 +55,21 @@ public class AbstractComboBoxListSwingModelTest {
 	public static void tearDownClass() {
 	}
 
+	@SuppressWarnings("serial")
 	static class LI extends AbstractComboBoxListSwingModel {
-		private static final long serialVersionUID = 1L;
+		ComboBoxModelProxy proxy;
 
 		public LI(int itemNumElems, List<SSListItem> itemList) {
 			super(itemNumElems, itemList);
+			proxy = getProxyJunitTextOnly();
 		}
+
 		@Override protected void checkState() { }
+		@Override protected void remodelTakeWriteLock() { }
+		@Override protected void remodelReleaseWriteLock(AbstractComboBoxListSwingModel.Remodel remodel) { }
 		@Override protected Remodel getRemodel() { return new RM(); }
 
 		class RM extends AbstractComboBoxListSwingModel.Remodel {
-			@Override protected void takeWriteLock() { }
-			@Override protected void releaseWriteLock() { }
 		}
 	}
 	

--- a/swingset/src/test/java/com/nqadmin/swingset/models/SSListItemFormatTest.java
+++ b/swingset/src/test/java/com/nqadmin/swingset/models/SSListItemFormatTest.java
@@ -96,19 +96,19 @@ public class SSListItemFormatTest {
 	public void tearDown() {
 	}
 
+	@SuppressWarnings("serial")
 	static class LI extends AbstractComboBoxListSwingModel {
-
-		private static final long serialVersionUID = 1L;
 
 		public LI(int itemNumElems, List<SSListItem> itemList) {
 			super(itemNumElems, itemList);
 		}
+
 		@Override protected void checkState() { }
+		@Override protected void remodelTakeWriteLock() { }
+		@Override protected void remodelReleaseWriteLock(AbstractComboBoxListSwingModel.Remodel remodel) { }
 		@Override protected Remodel getRemodel() { return new RM(); }
 
 		class RM extends AbstractComboBoxListSwingModel.Remodel {
-			@Override protected void takeWriteLock() { }
-			@Override protected void releaseWriteLock() { }
 		}
 	}
 


### PR DESCRIPTION
Glazed still handles locking.
https://github.com/bpangburn/swingset/issues/52.
OptionMappingSwingModel as a model created too many Remodel objects.
Move methods take/release lock from Remodel into AbstractModel.
Create/install model proxy; New test file for proxy.

All tests pass, new test created for proxy. Run demo with/without glazed.