### PR TITLE
cleanup warnings

### DIFF
--- a/swingset/src/main/java/com/nqadmin/swingset/SSComboBox.java
+++ b/swingset/src/main/java/com/nqadmin/swingset/SSComboBox.java
@@ -142,12 +142,10 @@ public class SSComboBox extends SSBaseComboBox<Integer, String, Object>
 {
 	private static final long serialVersionUID = 521308332266885608L;
 
-	@SuppressWarnings("serial")
 	private static class Model extends SSBaseComboBox.BaseModel<Integer, String, Object>
 	{
 	}
 
-	@SuppressWarnings("serial")
 	private static class GlazedModel extends SSBaseComboBox.BaseGlazedModel<Integer, String, Object>
 	{
 	}

--- a/swingset/src/main/java/com/nqadmin/swingset/SSDBComboBox.java
+++ b/swingset/src/main/java/com/nqadmin/swingset/SSDBComboBox.java
@@ -184,12 +184,10 @@ public class SSDBComboBox extends SSBaseComboBox<Long, Object, Object>
 	@Deprecated
 	public static final int NON_SELECTED = Integer.MIN_VALUE + 1;
 
-	@SuppressWarnings("serial")
 	private static class Model extends SSBaseComboBox.BaseModel<Long, Object, Object>
 	{
 	}
 
-	@SuppressWarnings("serial")
 	private static class GlazedModel extends SSBaseComboBox.BaseGlazedModel<Long, Object, Object>
 	{
 	}

--- a/swingset/src/main/java/com/nqadmin/swingset/SSList.java
+++ b/swingset/src/main/java/com/nqadmin/swingset/SSList.java
@@ -115,7 +115,6 @@ public class SSList extends JList<SSListItem> implements SSComponentInterface {
 	}
 
 	private static class Model extends OptionMappingSwingModel<Object, String, Object> {
-		private static final long serialVersionUID = 1L;
 		static Model install(JList<SSListItem> _jl) {
 			Model model = new Model();
 			AbstractComboBoxListSwingModel.install(_jl, model);

--- a/swingset/src/main/java/com/nqadmin/swingset/models/GlazedListsOptionMappingInfo.java
+++ b/swingset/src/main/java/com/nqadmin/swingset/models/GlazedListsOptionMappingInfo.java
@@ -57,7 +57,6 @@ import ca.odell.glazedlists.EventList;
  * @since 4.0.0
  */
 public class GlazedListsOptionMappingInfo<M,O,O2> extends OptionMappingSwingModel<M,O,O2> {
-	private static final long serialVersionUID = 1L;
 	private final EventList<SSListItem> eventList;
 	private boolean hasReturnedEventList;
 

--- a/swingset/src/main/java/com/nqadmin/swingset/models/OptionMappingSwingModel.java
+++ b/swingset/src/main/java/com/nqadmin/swingset/models/OptionMappingSwingModel.java
@@ -99,12 +99,12 @@ public class OptionMappingSwingModel<M,O,O2> extends AbstractComboBoxListSwingMo
 	public static OptionMappingSwingModel<?,?,?> asOptionMappingSwingModel(ListModel<SSListItem> _model) {
 
 		if (_model instanceof OptionMappingSwingModel) {
-			return (OptionMappingSwingModel) _model;
+			return (OptionMappingSwingModel<?,?,?>) _model;
 		}
 		if (_model instanceof ComboBoxListSwingModel) {
 			Object model = ((ComboBoxListSwingModel)_model).getComboBoxListSwingModel();
 			if (model instanceof OptionMappingSwingModel) {
-				return (OptionMappingSwingModel) model;
+				return (OptionMappingSwingModel<?,?,?>) model;
 			}
 		}
 		return null;
@@ -313,7 +313,7 @@ public class OptionMappingSwingModel<M,O,O2> extends AbstractComboBoxListSwingMo
 	/** {@inheritDoc} */
 	@Override protected void remodelTakeWriteLock() { }
 	/** {@inheritDoc} */
-	@Override protected void remodelReleaseWriteLock(AbstractComboBoxListSwingModel.Remodel remodel) { }
+	@Override protected void remodelReleaseWriteLock(AbstractComboBoxListSwingModel.Remodel _remodel) { }
 	
 	/** Methods for inspecting and modifying list info */
 	public class Remodel extends AbstractComboBoxListSwingModel.Remodel {

--- a/swingset/src/test/java/com/nqadmin/swingset/models/AbstractComboBoxListSwingModelEventTest.java
+++ b/swingset/src/test/java/com/nqadmin/swingset/models/AbstractComboBoxListSwingModelEventTest.java
@@ -68,7 +68,6 @@ public class AbstractComboBoxListSwingModelEventTest {
 	public static void tearDownClass() {
 	}
 
-	@SuppressWarnings("serial")
 	static class LI extends AbstractComboBoxListSwingModel {
 		ComboBoxModelProxy proxy;
 

--- a/swingset/src/test/java/com/nqadmin/swingset/models/AbstractComboBoxListSwingModelRemodelEventTest.java
+++ b/swingset/src/test/java/com/nqadmin/swingset/models/AbstractComboBoxListSwingModelRemodelEventTest.java
@@ -61,7 +61,6 @@ public class AbstractComboBoxListSwingModelRemodelEventTest {
 	public static void tearDownClass() {
 	}
 
-	@SuppressWarnings("serial")
 	static class LI extends AbstractComboBoxListSwingModel {
 		ComboBoxModelProxy proxy;
 

--- a/swingset/src/test/java/com/nqadmin/swingset/models/AbstractComboBoxListSwingModelTest.java
+++ b/swingset/src/test/java/com/nqadmin/swingset/models/AbstractComboBoxListSwingModelTest.java
@@ -55,7 +55,6 @@ public class AbstractComboBoxListSwingModelTest {
 	public static void tearDownClass() {
 	}
 
-	@SuppressWarnings("serial")
 	static class LI extends AbstractComboBoxListSwingModel {
 		ComboBoxModelProxy proxy;
 

--- a/swingset/src/test/java/com/nqadmin/swingset/models/SSListItemFormatTest.java
+++ b/swingset/src/test/java/com/nqadmin/swingset/models/SSListItemFormatTest.java
@@ -96,7 +96,6 @@ public class SSListItemFormatTest {
 	public void tearDown() {
 	}
 
-	@SuppressWarnings("serial")
 	static class LI extends AbstractComboBoxListSwingModel {
 
 		public LI(int itemNumElems, List<SSListItem> itemList) {


### PR DESCRIPTION
Most of the issues are because AbstractComboBoxListSwingModel is not actually extend a swing model anymore since it uses a proxy. So no "serial" required.