### PR TITLE
4.0.3 snapshot

### DIFF
--- a/swingset/CHANGELOG.txt
+++ b/swingset/CHANGELOG.txt
@@ -3,6 +3,18 @@ ChangeLog file for the SwingSet Open Toolkit for Java Swing.
 ==============================================================================
 
 ==============================================================================
+SwingSet 4.0.3 - Released 2021-02-22
+==============================================================================
+
+Changes:
+	1. SSBaseComboBox - Remove check against getBoundColumnText() because
+	   the rowset not updating as expected. New value from setBoundColumnText()
+	   is not reflected in getBoundColumnText() until after call to updateRow().
+	2. Add auto commit to Add button to be consistent with other buttons.
+	   Had to put dBNav.performPreInsertOps() in SwingUtilities.invokeLater()
+	   or insert row would show values from newly-committed record.
+
+==============================================================================
 SwingSet 4.0.2 - Released 2021-02-18
 ==============================================================================
 

--- a/swingset/src/main/java/com/nqadmin/swingset/SSBaseComboBox.java
+++ b/swingset/src/main/java/com/nqadmin/swingset/SSBaseComboBox.java
@@ -1014,9 +1014,13 @@ public abstract class SSBaseComboBox<M,O,O2> extends JComboBox<SSListItem> imple
 			//       setBoundColumnText or RowSetOps.updateColumnText
 
 			String tStringMapping = String.valueOf(mapping);
-			if (!Objects.equals(getBoundColumnText(), tStringMapping)) {
+			// 2021-02-22_BP: RowSet does not seem to support 'dirty' reads so 
+			// a call to getBoundColumnText() won't reflect any updates using
+			// setBoundColumnText() until after a call to updateRow().
+			
+			//if (!Objects.equals(getBoundColumnText(), tStringMapping)) {
 				setBoundColumnText(tStringMapping);
-			}
+			//}
 		}
 	
 		ssCommon.addRowSetListener();

--- a/swingset/src/main/java/com/nqadmin/swingset/SSDataNavigator.java
+++ b/swingset/src/main/java/com/nqadmin/swingset/SSDataNavigator.java
@@ -704,14 +704,16 @@ public class SSDataNavigator extends JPanel {
 			logger.debug("ADD button clicked.");
 			removeRowsetListener();
 			try {
-				
+				if (!commitChanges()) return;
+
 				rowSet.moveToInsertRow();
 				setInserting(rowSet, true);
 				if (navCombo!=null) {
 					navCombo.setEnabled(false);
 				}
 
-				dBNav.performPreInsertOps();
+				// If we don't use invokeLater() here, the values from the just-committed prior record are displayed for the insert row.
+				SwingUtilities.invokeLater(() -> dBNav.performPreInsertOps());
 				
 				updateButtonState();
 				


### PR DESCRIPTION
SSDataNavigator: Auto-commit prior to moveToInsertRow().

SSBaseComboBox: Remove check against getBoundColumnText() because rowset not updating. New value from setBoundColumnText() is not reflected in getBoundColumnText() until after call to updateRow(). No other components appear to have a 'dirty' column check.