### PR TITLE
Generic MaskFormatter that handles AllowNull

### DIFF
--- a/swingset-demo/src/main/java/com/nqadmin/swingset/demo/TestFormattedComponents.java
+++ b/swingset-demo/src/main/java/com/nqadmin/swingset/demo/TestFormattedComponents.java
@@ -56,6 +56,7 @@ import com.nqadmin.swingset.SSDBComboBox;
 import com.nqadmin.swingset.SSDBNavImpl;
 import com.nqadmin.swingset.SSDataNavigator;
 import com.nqadmin.swingset.SSTextField;
+import com.nqadmin.swingset.formatting.Format;
 import com.nqadmin.swingset.formatting.SSCuitField;
 import com.nqadmin.swingset.formatting.SSCurrencyField;
 import com.nqadmin.swingset.formatting.SSDateField;
@@ -98,6 +99,7 @@ public class TestFormattedComponents extends JFrame {
 	JLabel lblSSCuitField = new JLabel("SSCuitField");
 	JLabel lblSSCurrencyField = new JLabel("SSCurrencyField");
 	JLabel lblSSDateField = new JLabel("SSDateField");
+	JLabel lblSSDateFieldNull = new JLabel("SSDateFieldNull");
 	JLabel lblSSFormattedTextField = new JLabel("SSFormattedTextField");
 	JLabel lblSSIntegerField = new JLabel("SSIntegerField");
 	JLabel lblSSNumericField = new JLabel("SSNumericField");
@@ -112,7 +114,8 @@ public class TestFormattedComponents extends JFrame {
 	SSTextField txtSwingSetFormattedTestPK = new SSTextField();
 	SSCuitField fmtSSCuitField = new SSCuitField();
 	SSCurrencyField fmtSSCurrencyField = new SSCurrencyField();
-	SSDateField fmtSSDateField = new SSDateField(SSDateField.MMDDYYYY);
+	SSDateField fmtSSDateField = new SSDateField(Format.DATE_MMDDYYYY);
+	SSDateField fmtSSDateFieldNull = new SSDateField(Format.DATE_YYYYMMDD);
 	SSFormattedTextField fmtSSFormattedTextField = new SSFormattedTextField();
 	SSIntegerField fmtSSIntegerField = new SSIntegerField();
 	SSNumericField fmtSSNumericField = new SSNumericField();
@@ -274,6 +277,7 @@ public class TestFormattedComponents extends JFrame {
 				fmtSSCuitField.bind(rowset, "ss_cuit_field");
 				fmtSSCurrencyField.bind(rowset, "ss_currency_field");
 				fmtSSDateField.bind(rowset, "ss_date_field");
+				fmtSSDateFieldNull.bind(rowset, "ss_date_field_null");
 				fmtSSFormattedTextField.bind(rowset, "ss_formatted_text_field");
 				fmtSSIntegerField.bind(rowset, "ss_integer_field");
 				fmtSSNumericField.bind(rowset, "ss_numeric_field");
@@ -290,6 +294,7 @@ public class TestFormattedComponents extends JFrame {
 				lblSSCuitField.setPreferredSize(MainClass.labelDim);
 				lblSSCurrencyField.setPreferredSize(MainClass.labelDim);
 				lblSSDateField.setPreferredSize(MainClass.labelDim);
+				lblSSDateFieldNull.setPreferredSize(MainClass.labelDim);
 				lblSSFormattedTextField.setPreferredSize(MainClass.labelDim);
 				lblSSIntegerField.setPreferredSize(MainClass.labelDim);
 				lblSSNumericField.setPreferredSize(MainClass.labelDim);
@@ -306,6 +311,7 @@ public class TestFormattedComponents extends JFrame {
 				fmtSSCuitField.setPreferredSize(MainClass.ssDim);
 				fmtSSCurrencyField.setPreferredSize(MainClass.ssDim);
 				fmtSSDateField.setPreferredSize(MainClass.ssDim);
+				fmtSSDateFieldNull.setPreferredSize(MainClass.ssDim);
 				fmtSSFormattedTextField.setPreferredSize(MainClass.ssDim);
 				fmtSSIntegerField.setPreferredSize(MainClass.ssDim);
 				fmtSSNumericField.setPreferredSize(MainClass.ssDim);
@@ -331,6 +337,8 @@ public class TestFormattedComponents extends JFrame {
 				contentPane.add(lblSSCurrencyField, constraints);
 				constraints.gridy++;
 				contentPane.add(lblSSDateField, constraints);
+				constraints.gridy++;
+				contentPane.add(lblSSDateFieldNull, constraints);
 				constraints.gridy++;
 				contentPane.add(lblSSFormattedTextField, constraints);
 				constraints.gridy++;
@@ -358,6 +366,8 @@ public class TestFormattedComponents extends JFrame {
 				contentPane.add(fmtSSCurrencyField, constraints);
 				constraints.gridy++;
 				contentPane.add(fmtSSDateField, constraints);
+				constraints.gridy++;
+				contentPane.add(fmtSSDateFieldNull, constraints);
 				constraints.gridy++;
 				contentPane.add(fmtSSFormattedTextField, constraints);
 				constraints.gridy++;

--- a/swingset-demo/src/main/resources/mysql.swingset-demo-components.sql
+++ b/swingset-demo/src/main/resources/mysql.swingset-demo-components.sql
@@ -82,7 +82,8 @@ CREATE TABLE IF NOT EXISTS swingset_formatted_test_data
     swingset_formatted_test_pk INTEGER NOT NULL PRIMARY KEY,
     ss_cuit_field VARCHAR(13), /* Tax ID for the country of Argentina. See https://meta.cdq.ch/CUIT_number_(Argentina) */
     ss_currency_field DECIMAL(20,2),
-    ss_date_field DATE,
+    ss_date_field DATE NOT NULL,
+    ss_date_field_null DATE,
     ss_formatted_text_field VARCHAR(50), /* parent class for formatted components */
     ss_integer_field INT, 
     ss_numeric_field DECIMAL(20,4),
@@ -94,13 +95,13 @@ CREATE TABLE IF NOT EXISTS swingset_formatted_test_data
 
 
 INSERT INTO swingset_formatted_test_data VALUES
-    (1,'20-10563145-8',1234567.89,'2020-01-01','This is some random text 1.',2384709,4534.4321,0.99375,'111-22-3333','12:34:56',NULL),
-    (2,'23-10563146-8',7222567.11,'2021-02-03','This is some random text 2.',435634,1237643.1111,0.78345,'221-22-3333','12:00:00',NULL),
-    (3,'24-10563147-8',52347.23,'2020-02-29','This is some random text 3.',345237745,435652.2222,0.23456,'331-22-3333','01:22:33',NULL),
-    (4,'27-10563148-8',123567.34,'2022-03-04','This is some random text 4.',45234,4523456.3333,0.12345,'441-22-3333','00:15:20',NULL),
-    (5,'20-10563149-8',334567.45,'2020-04-05','This is some random text 5.',345,435645.4444,0.88888,'551-22-3333','23:44:55',NULL),
-    (6,'23-10563140-8',441234567.67,'2020-05-06','This is some random text 6.',95678467,5555.4321,1.00000,'661-22-3333','03:59:59',NULL),
-    (7,'24-10563141-8',77234567.89,'2020-06-07','This is some random text 7.',345678343,345645777345.6666,0.66666,'771-22-3333','14:55:00',NULL);
+    (1,'20-10563145-8',1234567.89,  '2020-01-01','2010-01-01','This is some random text 1.',2384709,4534.4321,0.99375,'111-22-3333','12:34:56',NULL),
+    (2,'23-10563146-8',7222567.11,  '2021-02-03','2011-02-03','This is some random text 2.',435634,1237643.1111,0.78345,'221-22-3333','12:00:00',NULL),
+    (3,'24-10563147-8',52347.23,    '2020-02-29','2010-02-29','This is some random text 3.',345237745,435652.2222,0.23456,'331-22-3333','01:22:33',NULL),
+    (4,'27-10563148-8',123567.34,   '2022-03-04','2012-03-04','This is some random text 4.',45234,4523456.3333,0.12345,'441-22-3333','00:15:20',NULL),
+    (5,'20-10563149-8',334567.45,   '2020-04-05','2010-04-05','This is some random text 5.',345,435645.4444,0.88888,'551-22-3333','23:44:55',NULL),
+    (6,'23-10563140-8',441234567.67,'2020-05-06','2010-05-06','This is some random text 6.',95678467,5555.4321,1.00000,'661-22-3333','03:59:59',NULL),
+    (7,'24-10563141-8',77234567.89, '2020-06-07','2010-06-07','This is some random text 7.',345678343,345645777345.6666,0.66666,'771-22-3333','14:55:00',NULL);
 
 
 

--- a/swingset-demo/src/main/resources/swingset_tests.sql
+++ b/swingset-demo/src/main/resources/swingset_tests.sql
@@ -81,7 +81,8 @@ CREATE TABLE IF NOT EXISTS swingset_formatted_test_data
     swingset_formatted_test_pk INTEGER DEFAULT nextval('swingset_formatted_test_seq') NOT NULL PRIMARY KEY,
     ss_cuit_field VARCHAR(13), /* Tax ID for the country of Argentina. See https://meta.cdq.ch/CUIT_number_(Argentina) */
     ss_currency_field DECIMAL(20,2),
-    ss_date_field DATE,
+    ss_date_field DATE NOT NULL,
+    ss_date_field_null DATE,
     ss_formatted_text_field VARCHAR(50), /* parent class for formatted components */
     ss_integer_field INT, 
     ss_numeric_field DECIMAL(20,4),
@@ -92,13 +93,13 @@ CREATE TABLE IF NOT EXISTS swingset_formatted_test_data
 );
 
 
-MERGE INTO swingset_formatted_test_data VALUES (1,'20-10563145-8',1234567.89,'2020-01-01','This is some random text 1.',2384709,4534.4321,0.99375,'111-22-3333','12:34:56',NULL);
-MERGE INTO swingset_formatted_test_data VALUES (2,'23-10563146-8',7222567.11,'2021-02-03','This is some random text 2.',435634,1237643.1111,0.78345,'221-22-3333','12:00:00',NULL);
-MERGE INTO swingset_formatted_test_data VALUES (3,'24-10563147-8',52347.23,'2020-02-29','This is some random text 3.',345237745,435652.2222,0.23456,'331-22-3333','01:22:33',NULL);
-MERGE INTO swingset_formatted_test_data VALUES (4,'27-10563148-8',123567.34,'2022-03-04','This is some random text 4.',45234,4523456.3333,0.12345,'441-22-3333','00:15:20',NULL);
-MERGE INTO swingset_formatted_test_data VALUES (5,'20-10563149-8',334567.45,'2020-04-05','This is some random text 5.',345,435645.4444,0.88888,'551-22-3333','23:44:55',NULL);
-MERGE INTO swingset_formatted_test_data VALUES (6,'23-10563140-8',441234567.67,'2020-05-06','This is some random text 6.',95678467,5555.4321,1.00000,'661-22-3333','03:59:59',NULL);
-MERGE INTO swingset_formatted_test_data VALUES (7,'24-10563141-8',77234567.89,'2020-06-07','This is some random text 7.',345678343,345645777345.6666,0.66666,'771-22-3333','14:55:00',NULL);
+MERGE INTO swingset_formatted_test_data VALUES (1,'20-10563145-8',1234567.89,  '2020-01-01','2010-01-01','This is some random text 1.',2384709,4534.4321,0.99375,'111-22-3333','12:34:56',NULL);
+MERGE INTO swingset_formatted_test_data VALUES (2,'23-10563146-8',7222567.11,  '2021-02-03','2011-02-03','This is some random text 2.',435634,1237643.1111,0.78345,'221-22-3333','12:00:00',NULL);
+MERGE INTO swingset_formatted_test_data VALUES (3,'24-10563147-8',52347.23,    '2020-02-29','2010-02-29','This is some random text 3.',345237745,435652.2222,0.23456,'331-22-3333','01:22:33',NULL);
+MERGE INTO swingset_formatted_test_data VALUES (4,'27-10563148-8',123567.34,   '2022-03-04','2012-03-04','This is some random text 4.',45234,4523456.3333,0.12345,'441-22-3333','00:15:20',NULL);
+MERGE INTO swingset_formatted_test_data VALUES (5,'20-10563149-8',334567.45,   '2020-04-05','2010-04-05','This is some random text 5.',345,435645.4444,0.88888,'551-22-3333','23:44:55',NULL);
+MERGE INTO swingset_formatted_test_data VALUES (6,'23-10563140-8',441234567.67,'2020-05-06','2010-05-06','This is some random text 6.',95678467,5555.4321,1.00000,'661-22-3333','03:59:59',NULL);
+MERGE INTO swingset_formatted_test_data VALUES (7,'24-10563141-8',77234567.89, '2020-06-07','2010-06-07','This is some random text 7.',345678343,345645777345.6666,0.66666,'771-22-3333','14:55:00',NULL);
 
 
 

--- a/swingset-demo/src/main/resources/swingset_tests.sql
+++ b/swingset-demo/src/main/resources/swingset_tests.sql
@@ -95,7 +95,7 @@ CREATE TABLE IF NOT EXISTS swingset_formatted_test_data
 
 MERGE INTO swingset_formatted_test_data VALUES (1,'20-10563145-8',1234567.89,  '2020-01-01','2010-01-01','This is some random text 1.',2384709,4534.4321,0.99375,'111-22-3333','12:34:56',NULL);
 MERGE INTO swingset_formatted_test_data VALUES (2,'23-10563146-8',7222567.11,  '2021-02-03','2011-02-03','This is some random text 2.',435634,1237643.1111,0.78345,'221-22-3333','12:00:00',NULL);
-MERGE INTO swingset_formatted_test_data VALUES (3,'24-10563147-8',52347.23,    '2020-02-29','2010-02-29','This is some random text 3.',345237745,435652.2222,0.23456,'331-22-3333','01:22:33',NULL);
+MERGE INTO swingset_formatted_test_data VALUES (3,'24-10563147-8',52347.23,    '2020-02-29','2010-02-28','This is some random text 3.',345237745,435652.2222,0.23456,'331-22-3333','01:22:33',NULL);
 MERGE INTO swingset_formatted_test_data VALUES (4,'27-10563148-8',123567.34,   '2022-03-04','2012-03-04','This is some random text 4.',45234,4523456.3333,0.12345,'441-22-3333','00:15:20',NULL);
 MERGE INTO swingset_formatted_test_data VALUES (5,'20-10563149-8',334567.45,   '2020-04-05','2010-04-05','This is some random text 5.',345,435645.4444,0.88888,'551-22-3333','23:44:55',NULL);
 MERGE INTO swingset_formatted_test_data VALUES (6,'23-10563140-8',441234567.67,'2020-05-06','2010-05-06','This is some random text 6.',95678467,5555.4321,1.00000,'661-22-3333','03:59:59',NULL);

--- a/swingset/src/main/java/com/nqadmin/swingset/SSDBNavImpl.java
+++ b/swingset/src/main/java/com/nqadmin/swingset/SSDBNavImpl.java
@@ -138,7 +138,7 @@ public class SSDBNavImpl implements SSDBNav {
 				// IF IT IS A SSFormattedTextField SET ITS VALUE TO NULL (to avoid parse
 				// exception)
 				if (comps[i] instanceof SSFormattedTextField) {
-					((SSFormattedTextField) comps[i]).setValue(null);
+					((SSFormattedTextField) comps[i]).cleanField();
 				} else {
 					// IF IT IS A JTextField SET ITS TEXT TO EMPTY STRING
 					((JTextField) comps[i]).setText("");

--- a/swingset/src/main/java/com/nqadmin/swingset/formatting/Format.java
+++ b/swingset/src/main/java/com/nqadmin/swingset/formatting/Format.java
@@ -46,7 +46,7 @@ public enum Format {
 	/** default date format */
 	DATE,
 	/** Date MMDDYYYY */
-	DATE_MMDDYYYY  (DATE),
+	DATE_MMDDYYYY (DATE),
 	/** Date DDMMYYYY */
 	DATE_DDMMYYYY (DATE),
 	/** Date YYYYMMDD */

--- a/swingset/src/main/java/com/nqadmin/swingset/formatting/Format.java
+++ b/swingset/src/main/java/com/nqadmin/swingset/formatting/Format.java
@@ -1,0 +1,87 @@
+/* *****************************************************************************
+ * Copyright (C) 2022, Prasanth R. Pasala, Brian E. Pangburn, & The Pangburn Group
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Contributors:
+ *   Prasanth R. Pasala
+ *   Brian E. Pangburn
+ *   Diego Gil
+ *   Man "Bee" Vo
+ *   Ernie R. Rael
+ * ****************************************************************************/
+package com.nqadmin.swingset.formatting;
+
+/**
+ * The various formats that are supported. There are Types, such as DATE and
+ * subtypes such as DATE_MMDDYYYY. If the type is used, this is the default
+ * format.
+ */
+public enum Format {
+	/** default date format */
+	DATE,
+	/** Date MMDDYYY */
+	DATE_MMDDYYYY  (DATE),
+	/** Date DDMMYYY */
+	DATE_DDMMYYYY (DATE),
+	/** Date YYYYMMDD */
+	DATE_YYYYMMDD (DATE) 
+	;
+
+	final private Format type;
+
+	/** the default has no args */
+	Format() {
+		type = this;
+	}
+
+	Format(Format _base) {
+		type = _base;
+	}
+
+	/** Is this enum value the default for the given type
+	 * @return true if this enum is the default.
+	 */
+	boolean isBase() {
+		return type == this;
+	}
+
+	/** The type of this format, e.g. DATE. 
+	 * @return type
+	 */
+	public Format getType() {
+		return type;
+	}
+
+	static Format getDefaultFormat(Format _format) {
+		switch(_format.getType()) {
+		case DATE: return DATE_DDMMYYYY;
+		}
+		return null;
+	}
+}

--- a/swingset/src/main/java/com/nqadmin/swingset/formatting/Format.java
+++ b/swingset/src/main/java/com/nqadmin/swingset/formatting/Format.java
@@ -45,9 +45,9 @@ package com.nqadmin.swingset.formatting;
 public enum Format {
 	/** default date format */
 	DATE,
-	/** Date MMDDYYY */
+	/** Date MMDDYYYY */
 	DATE_MMDDYYYY  (DATE),
-	/** Date DDMMYYY */
+	/** Date DDMMYYYY */
 	DATE_DDMMYYYY (DATE),
 	/** Date YYYYMMDD */
 	DATE_YYYYMMDD (DATE) 

--- a/swingset/src/main/java/com/nqadmin/swingset/formatting/SSDateField.java
+++ b/swingset/src/main/java/com/nqadmin/swingset/formatting/SSDateField.java
@@ -50,14 +50,14 @@ public class SSDateField extends SSFormattedTextField {
 
 	/**
 	 * constant representing the dd/mm/yyyy date format
-	 * @deprecated
+	 * @deprecated use {@link Format}'s DATE_DDMMYYYY
 	 */
 	@Deprecated
 	public static final int DDMMYYYY = 1;
 
 	/**
 	 * constant representing the mm/dd/yyyy date format
-	 * @deprecated 
+	 * @deprecated use {@link Format}'s DATE_MMDDYYYY
 	 */
 	@Deprecated
 	public static final int MMDDYYYY = 0;
@@ -67,52 +67,51 @@ public class SSDateField extends SSFormattedTextField {
 	 */
 	private static final long serialVersionUID = 9138021901389692436L;
 
-    /**
-     *  Creates a default SSDateField object
-     */
-    public SSDateField(){
-    	this(SSDateFormatterFactory.get());
-    }
+	/**
+	 *  Creates a default SSDateField object
+	 */
+	public SSDateField(){
+		this(SSDateFormatterFactory.get());
+	}
 
-    /**
-     *  Creates a new instance of SSDateField with the specified format
-     *  @param _format - format to be used while the date field is in edit mode
-     *  allowed values are MMDDYYYY or DDMMYYYY or YYYYMMDD
-     */
-    public SSDateField(final Format _format) {
-        this(SSDateFormatterFactory.get(_format));
-    }
+	/**
+	 *  Creates a new instance of SSDateField with the specified format
+	 *  @param _format - format to be used while the date field is in edit mode
+	 *  allowed values are MMDDYYYY or DDMMYYYY or YYYYMMDD
+	 */
+	public SSDateField(final Format _format) {
+		this(SSDateFormatterFactory.get(_format));
+	}
 
-    /**
-     *  Creates a new instance of SSDateField with the specified format
-     *  @param format - format to be used while the date field is in edit mode
-     *  allowed values are MMDDYYYY or DDMMYYYY
-     */
+	/**
+	 *  Creates a new instance of SSDateField with the specified format
+	 *  @param format - format to be used while the date field is in edit mode
+	 *  allowed values are MMDDYYYY or DDMMYYYY
+	 * @deprecated use {@link SSDateField#SSDateField(Format) }
+	 */
 	@Deprecated
-    public SSDateField(final int format) {
-        this(SSDateFormatterFactory.get(format));
-    }
+	public SSDateField(final int format) {
+		this(SSDateFormatterFactory.get(format));
+	}
 
-    /**
-     * Creates an object of SSDateField with the specified formatter factory
-     * @param factory - formatter factory to be used
-     */
-    public SSDateField(final javax.swing.JFormattedTextField.AbstractFormatterFactory factory) {
-        super(factory);
-		// TODO Consider setting to null vs system date.
-		if (!getAllowNull()) {
-			setValue(new java.util.Date());
-		}
-    }
+	/**
+	 * Creates an object of SSDateField with the specified formatter factory
+	 * @param factory - formatter factory to be used
+	 */
+	public SSDateField(final javax.swing.JFormattedTextField.AbstractFormatterFactory factory) {
+		super(factory);
+	}
 
-    /**
-     * Sets the value of the field to the current system date
-     */
-    @Override
+	/**
+	 * Sets the value of the field to an initial state consistent with
+	 * the AllowNull property. If not AllowNull the nuse the current system date.
+	 */
+	@Override
 	public void cleanField() {
-		// TODO Consider setting to null vs system date.
-		if (!getAllowNull()) {
+		if (getAllowNull()) {
+			setValue(null);
+		} else {
 			setValue(new java.util.Date());
 		}
-    }
+	}
 }

--- a/swingset/src/main/java/com/nqadmin/swingset/formatting/SSDateField.java
+++ b/swingset/src/main/java/com/nqadmin/swingset/formatting/SSDateField.java
@@ -50,12 +50,16 @@ public class SSDateField extends SSFormattedTextField {
 
 	/**
 	 * constant representing the dd/mm/yyyy date format
+	 * @deprecated
 	 */
+	@Deprecated
 	public static final int DDMMYYYY = 1;
 
 	/**
 	 * constant representing the mm/dd/yyyy date format
+	 * @deprecated 
 	 */
+	@Deprecated
 	public static final int MMDDYYYY = 0;
 
 	/**
@@ -67,7 +71,16 @@ public class SSDateField extends SSFormattedTextField {
      *  Creates a default SSDateField object
      */
     public SSDateField(){
-    	this(new SSDateFormatterFactory());
+    	this(SSDateFormatterFactory.get());
+    }
+
+    /**
+     *  Creates a new instance of SSDateField with the specified format
+     *  @param _format - format to be used while the date field is in edit mode
+     *  allowed values are MMDDYYYY or DDMMYYYY or YYYYMMDD
+     */
+    public SSDateField(final Format _format) {
+        this(SSDateFormatterFactory.get(_format));
     }
 
     /**
@@ -75,8 +88,9 @@ public class SSDateField extends SSFormattedTextField {
      *  @param format - format to be used while the date field is in edit mode
      *  allowed values are MMDDYYYY or DDMMYYYY
      */
+	@Deprecated
     public SSDateField(final int format) {
-        this(new SSDateFormatterFactory(format));
+        this(SSDateFormatterFactory.get(format));
     }
 
     /**
@@ -85,8 +99,10 @@ public class SSDateField extends SSFormattedTextField {
      */
     public SSDateField(final javax.swing.JFormattedTextField.AbstractFormatterFactory factory) {
         super(factory);
-        // TODO Consider setting to null vs system date.
-        setValue(new java.util.Date());
+		// TODO Consider setting to null vs system date.
+		if (!getAllowNull()) {
+			setValue(new java.util.Date());
+		}
     }
 
     /**
@@ -94,7 +110,9 @@ public class SSDateField extends SSFormattedTextField {
      */
     @Override
 	public void cleanField() {
-    	// TODO Consider setting to null vs system date.
-        setValue(new java.util.Date());
+		// TODO Consider setting to null vs system date.
+		if (!getAllowNull()) {
+			setValue(new java.util.Date());
+		}
     }
 }

--- a/swingset/src/main/java/com/nqadmin/swingset/formatting/SSDateField.java
+++ b/swingset/src/main/java/com/nqadmin/swingset/formatting/SSDateField.java
@@ -50,14 +50,14 @@ public class SSDateField extends SSFormattedTextField {
 
 	/**
 	 * constant representing the dd/mm/yyyy date format
-	 * @deprecated use {@link Format}'s DATE_DDMMYYYY
+	 * @deprecated use {@link Format#DATE_DDMMYYYY}
 	 */
 	@Deprecated
 	public static final int DDMMYYYY = 1;
 
 	/**
 	 * constant representing the mm/dd/yyyy date format
-	 * @deprecated use {@link Format}'s DATE_MMDDYYYY
+	 * @deprecated use {@link Format#DATE_MMDDYYYY}
 	 */
 	@Deprecated
 	public static final int MMDDYYYY = 0;

--- a/swingset/src/main/java/com/nqadmin/swingset/formatting/SSDateFormatterFactory.java
+++ b/swingset/src/main/java/com/nqadmin/swingset/formatting/SSDateFormatterFactory.java
@@ -58,7 +58,7 @@ public class SSDateFormatterFactory {
 
 	/**
 	 * Constant for dd/MM/yyyy date format
-	 * @deprecated 
+	 * @deprecated use {@link Format}'s DATE_DDMMYYYY
 	 */
 	@Deprecated
 	public static final int DDMMYYYY = 1;
@@ -70,14 +70,14 @@ public class SSDateFormatterFactory {
 
 	/**
 	 * Constant for MM/dd/yyyy date format
-	 * @deprecated 
+	 * @deprecated use {@link Format}'s DATE_MMDDYYYY
 	 */
 	@Deprecated
 	public static final int MMDDYYYY = 0;
 
 	/**
 	 * Constant for yyyy-MM-dd date format
-	 * @deprecated 
+	 * @deprecated use {@link Format}'s DATE_YYYYMMDD
 	 */
 	@Deprecated
 	public static final int YYYYMMDD = 2;
@@ -86,8 +86,6 @@ public class SSDateFormatterFactory {
 	 * Create formatter factory with default pattern.
 	 * @return
 	 */
-	// Don't like the way default is buried in get(Format) case label.
-	// Could add a default field in enum.
 	public static DefaultFormatterFactory get() {
 		return get(Format.DATE);
 	}

--- a/swingset/src/main/java/com/nqadmin/swingset/formatting/SSDateFormatterFactory.java
+++ b/swingset/src/main/java/com/nqadmin/swingset/formatting/SSDateFormatterFactory.java
@@ -40,6 +40,7 @@ package com.nqadmin.swingset.formatting;
 import java.text.SimpleDateFormat;
 
 import javax.swing.text.DateFormatter;
+import javax.swing.text.DefaultFormatterFactory;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -49,71 +50,118 @@ import org.apache.logging.log4j.Logger;
 // SwingSet - Open Toolkit For Making Swing Controls Database-Aware
 
 /**
- * SSDateFormatterFactory extends DefaultFormatterFactory for Date fields.
+ * Static methods to create a DefaultFormatterFactory for Date fields.
  */
-public class SSDateFormatterFactory extends javax.swing.text.DefaultFormatterFactory {
+public class SSDateFormatterFactory {
+
+	private SSDateFormatterFactory(){}
 
 	/**
 	 * Constant for dd/MM/yyyy date format
+	 * @deprecated 
 	 */
+	@Deprecated
 	public static final int DDMMYYYY = 1;
 
 	/**
 	 * Log4j Logger for component
 	 */
-	private static Logger logger = LogManager.getLogger();
+	private static final Logger logger = LogManager.getLogger();
 
 	/**
 	 * Constant for MM/dd/yyyy date format
+	 * @deprecated 
 	 */
+	@Deprecated
 	public static final int MMDDYYYY = 0;
 
 	/**
-	 * Unique serial ID
-	 */
-	private static final long serialVersionUID = -8205600502325364394L;
-
-	/**
 	 * Constant for yyyy-MM-dd date format
+	 * @deprecated 
 	 */
+	@Deprecated
 	public static final int YYYYMMDD = 2;
 
-    /**
-     * Constructs a default SSDateFormatterFactory.
-     */
-    public SSDateFormatterFactory() {
-    	this(DDMMYYYY);
-    }
+	/**
+	 * Create formatter factory with default pattern.
+	 * @return
+	 */
+	// Don't like the way default is buried in get(Format) case label.
+	// Could add a default field in enum.
+	public static DefaultFormatterFactory get() {
+		return get(Format.DATE);
+	}
+	/** compatibility
+	 * @param f
+	 * @return 
+	 */
+	@Deprecated
+	public static DefaultFormatterFactory get(int f) {
+		// Don't like the way default is buried in get
+		return get(getFormat(f));
+	}
 
-    /**
-     * Creates an object of SSDateFormatterFactory with the specified format.
-     * See https://docs.oracle.com/javase/8/docs/api/java/text/SimpleDateFormat.html
-     *
-     * @param format - Format to be used for date while in editing mode. The default format is DDMMYYYY
-     */
-    public SSDateFormatterFactory(final int format) {
-    	switch(format){
-    	case MMDDYYYY:
-    		setDefaultFormatter(new DateFormatter(new SimpleDateFormat("MM/dd/yyyy")));
-            setNullFormatter(null);
-            setEditFormatter(new DateFormatter(new SimpleDateFormat("MMddyyyy")));
-            setDisplayFormatter(new DateFormatter(new SimpleDateFormat("MM/dd/yyyy")));
-    		break;
-    	case DDMMYYYY:
-			setDefaultFormatter(new DateFormatter(new SimpleDateFormat("dd/MM/yyyy")));
-			setNullFormatter(null);
-			setEditFormatter(new DateFormatter(new SimpleDateFormat("ddMMyyyy")));
-			setDisplayFormatter(new DateFormatter(new SimpleDateFormat("dd/MM/yyyy")));
-    		break;
-    	case YYYYMMDD:
-			setDefaultFormatter(new DateFormatter(new SimpleDateFormat("yyyy-MM-dd")));
-			setNullFormatter(null);
-			setEditFormatter(new DateFormatter(new SimpleDateFormat("yyyyMMdd")));
-			setDisplayFormatter(new DateFormatter(new SimpleDateFormat("yyyy-MM-dd")));
-    		break;
-    	default:
-    		logger.warn("Unknown date format type of " + format);
-        	break;
-    	}
-    }
+	// NOTE: package private
+	@Deprecated
+	static Format getFormat(final int _format) {
+		switch (_format) {
+		case MMDDYYYY:
+			return Format.DATE_MMDDYYYY;
+		case DDMMYYYY:
+			return Format.DATE_DDMMYYYY;
+		case YYYYMMDD:
+			return Format.DATE_YYYYMMDD;
+		default:
+			return Format.DATE;
+		}
+	}
+
+	/**
+	 * Create formatter factory with specified format pattern.See https://docs.oracle.com/javase/8/docs/api/java/text/SimpleDateFormat.html
+	 * @param _format - Format to be used for date while in editing mode. The default format is DDMMYYYY
+	 * @return a DefaultFormatterFactory
+	 */
+	public static DefaultFormatterFactory get(Format _format) {
+		Format format = _format;
+		if ( _format.getType() != Format.DATE ) {
+			// I'd be inclined to exception
+			// throw new IllegalArgumentException(
+			// 		String.format("% is not a DATE", _format.toString()));
+			logger.error(() -> String.format("%s is not a DATE, using default",
+					_format.toString()));
+			format = Format.DATE;
+		}
+		if (format.isBase()) {
+			format = Format.getDefaultFormat(format);
+		}
+		String formatMask;
+		String editPattern;
+		String maskLiterals;
+		switch(format){
+			case DATE_MMDDYYYY:
+				formatMask = "##/##/####";
+				editPattern = "MMddyyyy";
+				maskLiterals = "/";
+				break;
+
+			case DATE_DDMMYYYY:
+				formatMask = "##/##/####";
+				editPattern = "ddMMyyyy";
+				maskLiterals = "/";
+				break;
+			case DATE_YYYYMMDD:
+				formatMask = "####-##-##";
+				editPattern = "yyyyMMdd";
+				maskLiterals = "-";
+				break;
+			default:
+				logger.error("Unknown date format type of " + format);
+				return null;
+		}
+
+		return new SSMaskFormatterFactory.Builder<>(formatMask)
+			.converter(new DateFormatter(new SimpleDateFormat(editPattern)))
+			.maskLiterals(maskLiterals).placeholder('_')
+			.build();
+	}
 }

--- a/swingset/src/main/java/com/nqadmin/swingset/formatting/SSDateFormatterFactory.java
+++ b/swingset/src/main/java/com/nqadmin/swingset/formatting/SSDateFormatterFactory.java
@@ -58,7 +58,7 @@ public class SSDateFormatterFactory {
 
 	/**
 	 * Constant for dd/MM/yyyy date format
-	 * @deprecated use {@link Format}'s DATE_DDMMYYYY
+	 * @deprecated use {@link Format#DATE_DDMMYYYY}
 	 */
 	@Deprecated
 	public static final int DDMMYYYY = 1;
@@ -70,14 +70,14 @@ public class SSDateFormatterFactory {
 
 	/**
 	 * Constant for MM/dd/yyyy date format
-	 * @deprecated use {@link Format}'s DATE_MMDDYYYY
+	 * @deprecated use {@link Format#DATE_MMDDYYYY}
 	 */
 	@Deprecated
 	public static final int MMDDYYYY = 0;
 
 	/**
 	 * Constant for yyyy-MM-dd date format
-	 * @deprecated use {@link Format}'s DATE_YYYYMMDD
+	 * @deprecated use {@link Format#DATE_YYYYMMDD}
 	 */
 	@Deprecated
 	public static final int YYYYMMDD = 2;

--- a/swingset/src/main/java/com/nqadmin/swingset/formatting/SSFormattedTextField.java
+++ b/swingset/src/main/java/com/nqadmin/swingset/formatting/SSFormattedTextField.java
@@ -589,7 +589,10 @@ public class SSFormattedTextField extends JFormattedTextField
 				logger.debug("{}: getObject() - " + newValue, () -> getColumnForLog());
 				setValue(newValue);
 			} else {
-				logger.error(getColumnForLog() + ": JDBCType of " + jdbcType.toString() + " was cast to unsupported type of " + newValue.getClass().getName() + " based on JDBC connection getTypeMap().");
+				String newValueString = newValue == null
+						? "(null)"
+						: newValue.getClass().getName();
+				logger.error(getColumnForLog() + ": JDBCType of " + jdbcType.toString() + " was cast to unsupported type of " + newValueString + " based on JDBC connection getTypeMap().");
 			}
 
 		} catch (final java.sql.SQLException sqe) {

--- a/swingset/src/main/java/com/nqadmin/swingset/formatting/SSFormattedTextField.java
+++ b/swingset/src/main/java/com/nqadmin/swingset/formatting/SSFormattedTextField.java
@@ -87,7 +87,6 @@ import com.nqadmin.swingset.utils.SSUtils;
 public class SSFormattedTextField extends JFormattedTextField
 		implements FocusListener, SSComponentInterface {
 
-	// static final boolean VISIBLE_ERROR_STATE = true;
 	/**
 	 * Implementing an InputVerifier in order to lock the focus down while the JFormattedTextField is in
 	 * an invalid edit state.
@@ -629,7 +628,6 @@ public class SSFormattedTextField extends JFormattedTextField
 
 	}
 
-	// experimental for VISIBLE_ERROR_STATE
 	void displayValidIndicator(boolean isValid) {
 		if(isValid) {
 			setBackground(isFocusOwner() ? focusBackgroundColor : standardBackgroundColor);

--- a/swingset/src/main/java/com/nqadmin/swingset/formatting/SSMaskFormatterFactory.java
+++ b/swingset/src/main/java/com/nqadmin/swingset/formatting/SSMaskFormatterFactory.java
@@ -108,7 +108,7 @@ public class SSMaskFormatterFactory extends DefaultFormatterFactory {
 	/**
 	 * Log4j Logger for component
 	 */
-	private static final Logger logger = LogManager.getLogger();
+	private static final Logger logger = SSUtils.getLogger();
 
 	/**
 	 * Get a new FormatterFactory with the specified parameters.Unless noted, a parameter is used when constructing the MaskFormatter.<p>

--- a/swingset/src/main/java/com/nqadmin/swingset/formatting/SSMaskFormatterFactory.java
+++ b/swingset/src/main/java/com/nqadmin/swingset/formatting/SSMaskFormatterFactory.java
@@ -1,0 +1,418 @@
+/* *****************************************************************************
+ * Copyright (C) 2022, Prasanth R. Pasala, Brian E. Pangburn, & The Pangburn Group
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Contributors:
+ *   Prasanth R. Pasala
+ *   Brian E. Pangburn
+ *   Diego Gil
+ *   Man "Bee" Vo
+ *   Ernie R. Rael
+ * ****************************************************************************/
+package com.nqadmin.swingset.formatting;
+
+import java.text.ParseException;
+
+import javax.swing.JFormattedTextField;
+import javax.swing.JFormattedTextField.AbstractFormatter;
+import javax.swing.text.DefaultFormatter;
+import javax.swing.text.DefaultFormatterFactory;
+import javax.swing.text.MaskFormatter;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * A FormatterFactory, with formatters based on MaskFormatter, which uses
+ * getAllowNull() from the SSFormattedTextField to determine when
+ * a NullFormatter should be provided. In addition, the 
+ * formatted text field is monitored and its value is changed
+ * to null/String as needed. This factory only specifies the default formatter,
+ * so edit and display formatters use the default formatter.
+ * <p>
+ * These formatters internally use a String value and the supplied converter
+ * is used to do the final conversion to a value of the correct type.
+ * Typically an AbstractFormatter is
+ * provided to convert objects to/from strings; see the code snippet below.
+ * The converter may not be needed if the value objects are a string.
+ * <p>
+ * Here's a code snippet that creates a {@link SSMaskFormatterFactory}
+ * that handles a {@link java.util.Date} field.
+ * <pre>{@code
+ *     new SSMaskFormatterFactory.Builder<>("##/##/####").maskLiterals("/")
+ *             .converter(new DateFormatter(new SimpleDateFormat("MMddyyyy")))
+ *             .placeholder('_').build();
+ * }</pre>
+ * With this snippet, if the text field has AllowNull true and the Value is
+ * null, then the text field is empty/blank; if the user then enters "1", 
+ * the text field displays "1_/__/____"/; if then backspace, the field
+ * becomes blank.
+ * Note the maskLiterals: the placeholder and maskLiterals are used
+ * when determining if the text field's value should be null;
+ * in particular, when it would contain "__/__/____" the value is set to null
+ * and the text field is empty; though conceivable, it is not simple to
+ * automatically determine the literals.
+ * Also note that the converter's format does not
+ * contain "/" because in this example the factory's
+ * {@link MaskFormatter}'s ValueContainsLiteralCharacters is false.
+ * <p>
+ * Finer control over the edit input characters can be obtained by
+ * overriding the Builder's getSSMaskFormatter to create a
+ * subclass of SSMaskFormatter which has a custom DocumentFilter. For example:
+ * <pre>{@code
+ * static class CustomBuilder extends SSMaskFormatterFactory.Builder<CustomBuilder> {
+ * 	   CustomBuilder(String mask) {
+ * 	   	super(mask);
+ * 	   }
+ * 	   @Override
+ * 	   protected SSMaskFormatter getSSMaskFormatter(
+ * 	   		SSMaskFormatterFactory.Builder<?> builder) throws ParseException {
+ * 	   	return new CustomSSMaskFormatter(self());
+ * 	   }
+ * }
+ * }</pre>
+ * Use this custom formatter as: {@code new CustomBuilder(formatMask)...build();}.
+ * <p>
+ * TODO: Should maskLiterals contain the placeholder rather than
+ * assuming placeholder should be filtered out?
+ */
+@SuppressWarnings("serial")
+public class SSMaskFormatterFactory extends DefaultFormatterFactory {
+
+	/**
+	 * Log4j Logger for component
+	 */
+	private static final Logger logger = LogManager.getLogger();
+
+	/**
+	 * Get a new FormatterFactory with the specified parameters.Unless noted, a parameter is used when constructing the MaskFormatter.<p>
+	 * <p>
+	 * TODO: extend to allow specification of a displayFormatter.
+	 * @see <em>Effective Java</em> Item 2 about override.
+	 * @param <T>
+	 */
+	public static class Builder<T extends Builder<T>> {
+		// Required params
+		private final String mask;
+		// Optional params
+		private String maskLiterals = "";
+		private boolean valueContainsLiterals = false;
+		private AbstractFormatter converter = null;
+		private Character placeholder = null;
+		private String validCharacters = null;
+		private String invalidCharacters = null;
+
+		/**
+		 * Create the builder.
+		 * @param mask Formatter's mask
+		 */
+		public Builder(String mask) {
+			this.mask = mask;
+		}
+
+		/** Literals in the mask; used in determining null data.
+		 * @param val
+		 * @return  builder */
+		public T maskLiterals(String val) { maskLiterals = val; return self(); }
+		/** formatter
+		 * @param val
+		 * @return  builder */
+		public T valueContainsLiteral(boolean val) { valueContainsLiterals = val; return self(); }
+		/** Used by the mask formatter in string2Value and value2String.
+		 * It's the last step in stringToValue; it produces the Value
+		 * in the formatted text field.
+		 * @param val
+		 * @return  builder */
+		public T converter(AbstractFormatter val) { converter = val; return self(); }
+		/** formatter
+		 * @param val
+		 * @return  builder */
+		public T placeholder(char val) { placeholder = val; return self(); }
+		/** formatter
+		 * @param val
+		 * @return  builder */
+		public T validCharacters(String val) { validCharacters = val; return self(); }
+		/** formatter
+		 * @param val
+		 * @return  builder */
+		public T invalidCharacters(String val) { invalidCharacters = val; return self(); }
+
+		/** create the factory
+		 * @return the factory */
+		public SSMaskFormatterFactory build() { return new SSMaskFormatterFactory(this); }
+		/**
+		 *
+		 * @return
+		 */
+
+		@SuppressWarnings("unchecked")
+		protected T self() {
+			return (T) this;
+		}
+
+		/**
+		 * Override this to provide custom SSMaskFormatter.
+		 * @param builder
+		 * @return
+		 * @throws ParseException 
+		 */
+		protected SSMaskFormatter getSSMaskFormatter(Builder<?> builder) throws ParseException {
+			return new SSMaskFormatter(builder);
+		}
+	}
+
+	/**
+	 * Create the factory, populate it with mask formatter.
+	 * @param builder
+	 */
+
+	protected SSMaskFormatterFactory(Builder<?> builder) {
+		try {
+			SSMaskFormatter mf = builder.getSSMaskFormatter(builder);
+			setDefaultFormatter(mf);
+		} catch (ParseException ex) {
+			logger.error("Bad mask format: " + builder.mask);
+		}
+	}
+	
+	/**
+	 * Ensure that a FormattedTextField's
+	 * DefaultFormatterFactory's NullFormatter is set
+	 * consistent with getAllowNull. If they do not agree, then
+	 * the factory's null formatter is set/cleared as needed.
+	 * 
+	 * @param _ftf 
+	 */
+	protected static void adjustNullFormatter(SSFormattedTextField _ftf) {
+		if (_ftf.getFormatterFactory() instanceof SSMaskFormatterFactory) {
+			SSMaskFormatterFactory ff = (SSMaskFormatterFactory) _ftf.getFormatterFactory();
+			boolean allowNull = _ftf.getAllowNull();
+			boolean hasNullFormatter = ff.getNullFormatter() != null;
+			if (allowNull ^ hasNullFormatter) {
+				ff.setNullFormatter(allowNull ? new SSNullFormatter() : null);
+			}
+		}
+	}
+
+	/** Uses setEditValid method to check that formatter should flip. */
+	@SuppressWarnings("serial")
+	protected static class SSMaskFormatter extends MaskFormatter {
+
+		private final AbstractFormatter converter;
+		private final String maskLiterals;
+
+		/**
+		 * 
+		 * @param builder
+		 * @throws ParseException 
+		 */
+		protected SSMaskFormatter(Builder<?> builder) throws ParseException {
+			super(builder.mask);
+			maskLiterals = builder.maskLiterals;
+			setValueContainsLiteralCharacters(builder.valueContainsLiterals);
+			converter = builder.converter;
+			if (builder.placeholder != null) {
+				setPlaceholderCharacter(builder.placeholder);
+			}
+			if (builder.validCharacters != null) {
+				setValidCharacters(builder.validCharacters);
+			}
+			if (builder.invalidCharacters != null) {
+				setValidCharacters(builder.invalidCharacters);
+			}
+			
+			// NOTE:  following required to flip as needed
+			// DO NOT CHANGE
+			setCommitsOnValidEdit(true);
+
+			// DO NOT CHANGE
+			setValueClass(String.class);
+		}
+
+		/**
+		 *
+		 * @return
+		 */
+		public AbstractFormatter getConverter() {
+			return converter;
+		}
+
+		/**
+		 *
+		 * @return
+		 */
+		public String getLiterals() {
+			return maskLiterals;
+		}
+
+		/**
+		 * If the value is not a String and there is a converter,
+		 * then first convert the value before super.valueToString.
+		 * @param value
+		 * @return String representation of the value
+		 * @throws ParseException 
+		 */
+		@Override
+		public String valueToString(Object value) throws ParseException {
+			String s = "";
+			if (value != null) {
+				if (value instanceof String) {
+					// handle the case where where was null formatter
+					s = (String) value;
+				} else {
+					if (converter != null) {
+						s = converter.valueToString(value);
+					} else {
+						s = value.toString();
+					}
+				}
+			}
+			s = super.valueToString(s);
+			return s;
+		}
+
+		/**
+		 * First convert the string with super.stringToValue,
+		 * then use the converter (if there is one) to create
+		 * the value object.
+		 * @param s
+		 * @return
+		 * @throws ParseException 
+		 */
+		@Override
+		public Object stringToValue(String s) throws ParseException {
+			if (s == null || s.trim().isEmpty()) {
+				return null;
+			}
+			Object v = super.stringToValue(s);
+			if (converter != null) {
+				v = converter.stringToValue((String) v);
+			}
+			return v;
+		}
+
+		/**
+		 * This method is invoked by the formatter when it is almost done.
+		 * After super.setEditValid, if the text field does not have
+		 * user input, set the value to null (which switches the formatter).
+		 * @param valid
+		 */
+		@Override
+		protected void setEditValid(boolean valid) {
+			super.setEditValid(valid);
+			// Check for empty string input.
+			// If empty and allows null, flip to NullFormatter
+			final JFormattedTextField ftf = getFormattedTextField();
+			if (ftf instanceof SSFormattedTextField) {
+				// If doesn't allow null, don't even consider switching value
+				if (!((SSFormattedTextField)ftf).getAllowNull()) {
+					return;
+				}
+				if (containsData(ftf.getText())) {
+					return;
+				}
+				ftf.setValue(null);
+			}
+		}
+
+		/**
+		 * Check the string for user data.
+		 * @param _text generally formatted text field
+		 * @return true if there is user input in the text
+		 */
+		protected boolean containsData (String _text) {
+			// first remove placeholder characters from the text
+			String text = _text.replace(String.valueOf(getPlaceholderCharacter()), "");
+			for (int i = 0; i < text.length(); i++) {
+				String c = String.valueOf(text.charAt(i));
+				if (!maskLiterals.contains(c)) {
+					// encountered some data, not empty
+					return true;
+				}
+			}
+			return false;
+		}
+	}
+
+	/** use setEditValid method to check that formatter should flip */
+	@SuppressWarnings("serial")
+	protected static class SSNullFormatter extends DefaultFormatter {
+
+		/**
+		 * The null formatter.
+		 */
+		public SSNullFormatter() {
+			// DO NOT CHANGE
+			setValueClass(String.class);
+			// DO NOT CHANGE
+			setCommitsOnValidEdit(true);
+		}
+
+		/**
+		 * This method is invoked by the formatter when it is almost done.
+		 * After super.setEditValid, if the text field is a String
+		 * set the value to the String (which switches the formatter).
+		 * @param valid
+		 */
+		@Override
+		protected void setEditValid(boolean valid) {
+			super.setEditValid(valid);
+			
+			// if a character was added to the Null Formatter,
+			// then use setValue to flip to the MaskFormatter.
+			final JFormattedTextField ftf = getFormattedTextField();
+			Object value = ftf.getValue();
+			// May not need to check for SSNullFormatter, but things change :-)
+			if(value instanceof String
+					&& ftf.getFormatter() instanceof SSNullFormatter) {
+				try {
+					ftf.setValue(value);
+					// If ftf is still the null formatter,
+					// then MaskFormatter didn't like the value;
+					// notify and get out.
+					if (ftf.getFormatter() instanceof SSNullFormatter) {
+						invalidEdit();
+						return;
+					}
+					ftf.getFormatter().valueToString(value);
+					// Attempt to put the caret after the character.
+					try {
+						ftf.setCaretPosition(((String)value).length());
+					} catch (IllegalArgumentException ex) {
+					}
+				} catch(ParseException ex) {
+					// mask formatter (probably) got an exception,
+					// back to the null formatter
+					ftf.setValue(null);
+				}
+			}
+		}
+	}
+	
+}

--- a/swingset/src/test/java/com/nqadmin/swingset/formatting/SSMaskFormatterFactoryTest.java
+++ b/swingset/src/test/java/com/nqadmin/swingset/formatting/SSMaskFormatterFactoryTest.java
@@ -1,0 +1,242 @@
+/* *****************************************************************************
+ * Copyright (C) 2022, Prasanth R. Pasala, Brian E. Pangburn, & The Pangburn Group
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Contributors:
+ *   Prasanth R. Pasala
+ *   Brian E. Pangburn
+ *   Diego Gil
+ *   Man "Bee" Vo
+ *   Ernie R. Rael
+ * ****************************************************************************/
+package com.nqadmin.swingset.formatting;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Most of the testing in here is to build class hierarchies
+ * of factory/builder pairs and seeing if they compile.
+ * These can provide examples.
+ * The tests verify that the data gets through the builder to the formatter.
+ * @author err
+ */
+@SuppressWarnings("javadoc")
+public class SSMaskFormatterFactoryTest {
+	
+	/** x */
+	public SSMaskFormatterFactoryTest() {
+	}
+	
+	/** x */
+	@BeforeAll
+	public static void setUpClass() {
+	}
+	
+	/** x */
+	@AfterAll
+	public static void tearDownClass() {
+	}
+	
+	/** x */
+	@BeforeEach
+	public void setUp() {
+	}
+	
+	/** x */
+	@AfterEach
+	public void tearDown() {
+	}
+
+	/** x */
+	@SuppressWarnings("serial")
+	public static class CustomParentFormatterFactory
+			extends SSMaskFormatterFactory {
+
+		/** @param <T> */
+		public static class CustomParentBuilder<T extends CustomParentBuilder<T>>
+				extends SSMaskFormatterFactory.Builder<CustomParentBuilder<T>> {
+			private final String parentArg;
+			private String parentParam = "defaultParentParam";
+
+			/** *  @param mask
+			 * @param arg */
+			public CustomParentBuilder(String mask, String arg) {
+				super(mask);
+				parentArg = arg;
+			}
+
+			/** @param val
+			 * @return */
+			public T parentParam(String val) { parentParam = val; return self(); }
+
+			/** @return */
+			@Override
+			public CustomParentFormatterFactory build() { return new CustomParentFormatterFactory(this); }
+			
+			/** @return */
+			@Override
+			@SuppressWarnings("unchecked")
+			protected T self() {
+				return (T) this;
+			}
+		}
+
+		private final String parentArg;
+		private final String parentParam;
+		/** @param builder */
+		public CustomParentFormatterFactory(CustomParentBuilder<?> builder) {
+			super(builder);
+			parentArg = builder.parentArg;
+			parentParam = builder.parentParam;
+		}
+
+		String getParentArg() { return parentArg; }
+		String getParentParam() { return parentParam; }
+	}
+
+	/** x */
+	@SuppressWarnings("serial")
+	public static class CustomChildFormatterFactory
+			extends CustomParentFormatterFactory {
+
+		/** @param <T> */
+		public static class CustomChildBuilder<T extends CustomChildBuilder<T>>
+				extends CustomParentBuilder<CustomChildBuilder<T>> {
+			private final String childArg;
+			private String childParam = "defaultChildParam";
+
+			/** @param mask
+			 * @param argP
+			 * @param argC */
+			public CustomChildBuilder(String mask, String argP, String argC) {
+				super(mask, argP);
+				childArg = argC;
+			}
+
+			/** @param val
+			 * @return */
+			public T childParam(String val) { childParam = val; return self(); }
+
+			/** @return */
+			@Override
+			public CustomChildFormatterFactory build() { return new CustomChildFormatterFactory(this); }
+
+			/** @return */
+			@Override
+			@SuppressWarnings("unchecked")
+			protected T self() {
+				return (T) this;
+			}
+		}
+
+		private final String childArg;
+		private final String childParam;
+		/** @param builder */
+		public CustomChildFormatterFactory(CustomChildBuilder<?> builder) {
+			super(builder);
+			childArg = builder.childArg;
+			childParam = builder.childParam;
+		}
+
+		String getChildArg() { return childArg; }
+		String getChildParam() { return childParam; }
+	}
+
+	/** x */
+	@Test
+	public void testParentHier() {
+		CustomParentFormatterFactory.CustomParentBuilder<?> b
+				= new CustomParentFormatterFactory
+						.CustomParentBuilder<>("##/##", "parentArg")
+						.maskLiterals("AB").parentParam("parentParam");
+		CustomParentFormatterFactory ff = b.build();
+		assertEquals("parentArg", ff.getParentArg());
+		assertEquals("parentParam", ff.getParentParam());
+		SSMaskFormatterFactory.SSMaskFormatter f
+				= (SSMaskFormatterFactory.SSMaskFormatter) ff.getDefaultFormatter();
+		assertEquals("##/##", f.getMask());
+		assertEquals("AB", f.getLiterals());
+	}
+
+	/** x */
+	@Test
+	public void testChildHier() {
+		CustomChildFormatterFactory.CustomChildBuilder<?> b
+				= new CustomChildFormatterFactory
+						.CustomChildBuilder<>("##/##", "parentArg", "childArg")
+						.maskLiterals("AB")
+						.parentParam("parentParam").childParam("childParam");
+		CustomChildFormatterFactory ff = b.build();
+		assertEquals("parentArg", ff.getParentArg());
+		assertEquals("parentParam", ff.getParentParam());
+		assertEquals("childArg", ff.getChildArg());
+		assertEquals("childParam", ff.getChildParam());
+		SSMaskFormatterFactory.SSMaskFormatter f
+				= (SSMaskFormatterFactory.SSMaskFormatter) ff.getDefaultFormatter();
+		assertEquals("##/##", f.getMask());
+		assertEquals("AB", f.getLiterals());
+	}
+
+	/**
+	 * Test of builder method, of class SSMaskFormatterFactory.
+	 */
+	//@Test
+	//@SuppressWarnings("UseOfSystemOutOrSystemErr")
+	//public void testBuilder() {
+	//	System.out.println("builder");
+	//	String mask = "";
+	//	@SuppressWarnings("rawtypes")
+	//	SSMaskFormatterFactory.Builder expResult = null;
+	//	@SuppressWarnings("rawtypes")
+	//	SSMaskFormatterFactory.Builder result = SSMaskFormatterFactory.builder(mask);
+	//	assertEquals(expResult, result);
+	//	// TODO review the generated test code and remove the default call to fail.
+	//	fail("The test case is a prototype.");
+	//}
+
+	/**
+	 * Test of adjustNullFormatter method, of class SSMaskFormatterFactory.
+	 */
+	//@Test
+	//@SuppressWarnings("UseOfSystemOutOrSystemErr")
+	//public void testAdjustNullFormatter() {
+	//	System.out.println("adjustNullFormatter");
+	//	SSFormattedTextField _ftf = null;
+	//	SSMaskFormatterFactory.adjustNullFormatter(_ftf);
+	//	// TODO review the generated test code and remove the default call to fail.
+	//	fail("The test case is a prototype.");
+	//}
+	
+}


### PR DESCRIPTION
This has the basics.  This mask formatter used in `SSDateField` and it's `Factory`.

Added `Format` enum, rather than DateFormat enum, probably controversial. Not sure how I feel about it, but in terms of allowing an app to specify it's own default formats this might be handy starting place. Can discuss in #18 or this PR.

Wanted to set initial state of `SSDateField`, after Nav's AddRecord button is pushed, to either null or current date depending on AllowNull. I put the logic in `SSDateField.cleanField()` but it never gets called (from anywhere). Any idea how this can be done?

At the very top there's `SSFormatteTextField.VISIBLE_ERROR_STATE`. When true, the field goes redish when it hold an invalid value. When false, it has the previous behavior and the field goes red when you try to leave the field and it's invalid. I had difficulty getting the new behavior to match the old behavior, any idea?