### PR TITLE
Component null pointer fixes

### DIFF
--- a/swingset/src/main/java/com/nqadmin/swingset/SSDBComboBox.java
+++ b/swingset/src/main/java/com/nqadmin/swingset/SSDBComboBox.java
@@ -363,14 +363,25 @@ public class SSDBComboBox extends SSBaseComboBox<Long, Object, Object>
 	 * @param _option text that should be displayed in the combobox
 	 * @param _mapping  mapping of _option, typically a primary key
 	 */
-	public void addOption(String _option, Long _mapping) {
+	public void addOption(Object _option, Long _mapping) {
+		addOption(_option, null, _mapping);
+	}
+	
+	/**
+	 * Adds an item to the existing list of items in the combo box.
+	 *
+	 * @param _option text that should be displayed in the combobox
+	 * @param _option2  second display text for combobox
+	 * @param _mapping  mapping of _option, typically a primary key
+	 */
+	public void addOption(Object _option, Object _option2, Long _mapping) {
 		try (Model.Remodel remodel = optionModel.getRemodel()) {
 			final int index = remodel.getMappings().indexOf(_mapping);
 			if (index >= 0) {
 				logger.warn(() -> String.format("%s: Mapping of [%s] already exists. Creating duplicate Mapping with Option of '%s'.",
 					getColumnForLog(), _mapping, _option));
 			}
-			remodel.add(_mapping, _option);
+			remodel.add(_mapping, _option, _option2);
 		} catch (final Exception e) {
 			logger.error(getColumnForLog() + ": Exception.", e);
 		}

--- a/swingset/src/main/java/com/nqadmin/swingset/SSDBComboBox.java
+++ b/swingset/src/main/java/com/nqadmin/swingset/SSDBComboBox.java
@@ -360,7 +360,7 @@ public class SSDBComboBox extends SSBaseComboBox<Long, Object, Object>
 	/**
 	 * Adds an item to the existing list of items in the combo box.
 	 *
-	 * @param _option text that should be displayed in the combobox
+	 * @param _option item that should be displayed in the combobox
 	 * @param _mapping  mapping of _option, typically a primary key
 	 */
 	public void addOption(Object _option, Long _mapping) {
@@ -370,8 +370,8 @@ public class SSDBComboBox extends SSBaseComboBox<Long, Object, Object>
 	/**
 	 * Adds an item to the existing list of items in the combo box.
 	 *
-	 * @param _option text that should be displayed in the combobox
-	 * @param _option2  second display text for combobox
+	 * @param _option item that should be displayed in the combobox
+	 * @param _option2  second display item for combobox
 	 * @param _mapping  mapping of _option, typically a primary key
 	 */
 	public void addOption(Object _option, Object _option2, Long _mapping) {

--- a/swingset/src/main/java/com/nqadmin/swingset/SSDBComboBox.java
+++ b/swingset/src/main/java/com/nqadmin/swingset/SSDBComboBox.java
@@ -196,7 +196,7 @@ public class SSDBComboBox extends SSBaseComboBox<Long, Object, Object>
 	 */
 	@Override
 	protected SSListItem createNullItem(Model.Remodel remodel) {
-		return remodel.createOptionMappingItem(null, "", null);
+		return remodel.createOptionMappingItem(null, null, null);
 	}
 
 	/**

--- a/swingset/src/main/java/com/nqadmin/swingset/formatting/SSFormattedTextField.java
+++ b/swingset/src/main/java/com/nqadmin/swingset/formatting/SSFormattedTextField.java
@@ -516,7 +516,7 @@ public class SSFormattedTextField extends JFormattedTextField
 		try {
 			// IF THERE ARE NO RECORDS OR THE COLUMN VALUE IS NULL SET THE FIELD TO NULL AND RETURN
 			//if ((getRowSet().getColumnCount()==0) || (getRowSet().getObject(getBoundColumnName()) == null)) {
-			if ((RowSetOps.getColumnCount(getRowSet())==0) || (getRowSet().getObject(getBoundColumnName()) == null)) {
+			if ( getRowSet().getRow() < 1 || RowSetOps.getColumnCount(getRowSet())==0 || getRowSet().getObject(getBoundColumnName()) == null ) {
 				setValue(null);
 				return;
 			}


### PR DESCRIPTION
Made another change to the createNullItem which is used to create a Item for the SSDBComboBox (used for Navigation) when a new record is added. Here were are using a empty string for the display value, when the field is a date field we try to format it and we added a null check but since we are using a empty string when creating a null item it causes a IllegalArgumentException. So changed the empty string to null when creating a NullItem