### PR TITLE
Use Format for SSListItemFormat; all types

### DIFF
--- a/swingset/src/main/java/com/nqadmin/swingset/models/SSListItemFormat.java
+++ b/swingset/src/main/java/com/nqadmin/swingset/models/SSListItemFormat.java
@@ -47,7 +47,10 @@ import java.util.EnumMap;
 import java.util.List;
 import java.util.Objects;
 
+import org.apache.logging.log4j.Logger;
+
 import com.nqadmin.swingset.models.AbstractComboBoxListSwingModel.ListItem0;
+import com.nqadmin.swingset.utils.SSUtils;
 
 // SSListItemFormat.java
 //
@@ -56,22 +59,27 @@ import com.nqadmin.swingset.models.AbstractComboBoxListSwingModel.ListItem0;
 /**
  * Use this to produce a string representation of an SSListItem.
  * Configure the order in which the list item elements are formatted,
- * and each element type, with {@link #addElemType}.
+ * each element type, and optionally Format,
+ * with {@link #addElemType(int, java.sql.JDBCType, java.text.Format) }.
  * After this object is created, by default
  * element 0 is formatted with toString(). Start with {@link #clear()}
  * to set up a different formatting specification.
  * <p>
- * Time related elements can have a format pattern specified;
- * The time patterns use {@link java.text.SimpleDateFormat}.
- * If the pattern is null, then toString() is used to format the pattern.
+ * Each JDBCType can have a default Format specified; use
+ * {@link #setFormat(java.sql.JDBCType, java.text.Format) }.
+ * There are preset defaults for the data/time types
  * <pre>
  * {@code
- * The default patterns are:
+ * The builtin default Formats {@link java.text.SimpleDateFormat} are:
  *    JDBCType.DATE       "yyyy/MM/dd"
  *    JDBCType.TIME,      "HH:mm:ss"
  *    JDBCType.TIMESTAMP, "yyyy/MM/dd'T'HH:mm:ss"
  * }
  * </pre>
+ * When an elem is formatted, first a format assigned to the elem is checked,
+ * then the default format for the elem type is checked,
+ * if neither is available, then toString() is used to format the elem.
+ * the default time formats use .
  * <p>
  * Use {@link #format(java.lang.Object)}, where the argument
  * is an SSListItem, to get the String representation. Note
@@ -82,18 +90,6 @@ import com.nqadmin.swingset.models.AbstractComboBoxListSwingModel.ListItem0;
  * 
  * @since 4.0.0
  */
-// TODO: Handle considerably more config for specific elem formatting
-//		map: {elemIndex:jdbcType} DONE
-//		map: {jdbcType:format} NO, there's a format for DATE
-//		map: {elemIndex:format} to override the defaults
-//		possibly option to specify function associated with elemIndex
-//
-// TODO: How about an object which describes an SSListItem properties,
-//		 this would include elements database type, format, ...
-//		 Then use this in preference to individually configuring elems.
-//		 But there's typically only one elem of SSListItem that
-//		 contributes to string description, so...
-//
 public class SSListItemFormat extends Format {
 	/** default date format */
 	public static final String dateDefault = "yyyy/MM/dd";
@@ -107,13 +103,34 @@ public class SSListItemFormat extends Format {
 	private static final FieldPosition FP0 = new FieldPosition(0);
 
 	private String separator = defaultSeparator;
-	/** elemTypes.get(elemIndex) == jdbcType. Cheap map. Null is unspecified type */
-	protected List<JDBCType> elemTypes = new ArrayList<>(4);
-	/** format these item elem in order */
+	/** elemInfos.get(elemIndex) == elemInfo. */
+	protected List<ElemInfo> elemInfos = new ArrayList<>(4);
+	/** format these elem in order of List. */
 	protected List<Integer> itemElemIndexes = new ArrayList<>(4);
 
 	// allow customization of date/time formats
-	private EnumMap<JDBCType, String> patterns = new EnumMap<>(JDBCType.class);
+	private final EnumMap<JDBCType, Format> formats = new EnumMap<>(JDBCType.class);
+
+	private static Logger logger = SSUtils.getLogger();
+
+	/**
+	 * Encapsulate info about element in SSListInfo.
+	 */
+	protected static class ElemInfo {
+		/** type of the elem */
+		final JDBCType type;
+		/** Format to use with this elem, may be null */
+		final Format format;
+
+		/**
+		 * @param type
+		 * @param format
+		 */
+		protected ElemInfo(JDBCType type, Format format) {
+			this.type = type;
+			this.format = format;
+		}
+	}
 
 	
 	/**
@@ -121,14 +138,15 @@ public class SSListItemFormat extends Format {
 	 * elements, in order, that are formatted.
 	 * By default, element 0 is formatted with toString()
 	 */
+	@SuppressWarnings("OverridableMethodCallInConstructor")
 	public SSListItemFormat() {
 		// format elment 0 with toString()
 		addElemType(0, JDBCType.NULL);
 
 		// initialize default format patterns
-		patterns.put(JDBCType.DATE, dateDefault);
-		patterns.put(JDBCType.TIME, timeDefault);
-		patterns.put(JDBCType.TIMESTAMP, timestampDefault);
+		formats.put(JDBCType.DATE,      new SimpleDateFormat(dateDefault));
+		formats.put(JDBCType.TIME,      new SimpleDateFormat(timeDefault));
+		formats.put(JDBCType.TIMESTAMP, new SimpleDateFormat(timestampDefault));
 	}
 
 	/**
@@ -137,28 +155,65 @@ public class SSListItemFormat extends Format {
 	 * Note that default formatting patterns are not restored.
 	 */
 	public void clear() {
-		elemTypes.clear();
+		elemInfos.clear();
 		itemElemIndexes.clear();
 	}
 
 	/**
-	 * Add element for formatting. Elements are formatted in
+	 * Add element for formatting.Elements are formatted in
 	 * the same order as they are added. If the same elemIndex
-	 * is added, the previous information is discarded.
+ 	 * is added, the previous information is discarded.
+	 * 
+	 * @param _elemIndex ListItem elemIndex for formatting
+	 * @param _jdbcType type of element
+	 * @param _format format to use for the element, may be null
+	 */
+	public void addElemType(int _elemIndex, JDBCType _jdbcType, Format _format) {
+		Objects.requireNonNull(_jdbcType);
+		// first make sure there's room
+		while (_elemIndex >= elemInfos.size()) {
+			elemInfos.add(null);
+		}
+		elemInfos.set(_elemIndex, new ElemInfo(_jdbcType, _format));
+
+		// SSListItem is formatted in the order the items are added
+		Integer indexAsObject = _elemIndex;
+		itemElemIndexes.remove(indexAsObject);
+		itemElemIndexes.add(indexAsObject);
+	}
+
+	/**
+	 * Add element for formatting.Elements are formatted in
+	 * the same order as they are added. If the same elemIndex
+ 	 * is added, the previous information is discarded.
+	 * The default Format for this type is used.
 	 * 
 	 * @param _elemIndex ListItem elemIndex for formatting
 	 * @param _jdbcType type of element
 	 */
 	public void addElemType(int _elemIndex, JDBCType _jdbcType) {
-		Objects.requireNonNull(_jdbcType);
-		// first make sure there's room
-		while (_elemIndex >= elemTypes.size()) {
-			elemTypes.add(null);
-		}
-		elemTypes.set(_elemIndex, _jdbcType);
-		Integer indexAsObject = _elemIndex;
-		itemElemIndexes.remove(indexAsObject);
-		itemElemIndexes.add(indexAsObject);
+		addElemType(_elemIndex, _jdbcType, null);
+	}
+
+	/**
+	 * Set the default Format for the specified jdbc type.
+	 * Only the {@link Format#format(Object, StringBuffer, java.text.FieldPosition)}
+	 * method is used with the argument Format.
+	 * @param _jdbcType all elements of this type use the specified format
+	 * @param _format the format
+	 * @return the previous format
+	 */
+	public Format setFormat(JDBCType _jdbcType, Format _format) {
+		return formats.put(_jdbcType, _format);
+	}
+
+	/**
+	 * Get the default Format for the specified JDBCType.
+	 * @param _jdbcType
+	 * @return format or null if no format has been set
+	 */
+	public Format getFormat(JDBCType _jdbcType) {
+		return formats.get(_jdbcType);
 	}
 
 	/**
@@ -169,12 +224,24 @@ public class SSListItemFormat extends Format {
 	 * @param _jdbcType all elements of this type use the specified pattern
 	 * @param _pattern format pattern
 	 * @return the previous format string
+	 * @deprecated Use {@link #setFormat(java.sql.JDBCType, java.text.Format) }
 	 */
+	@Deprecated
 	public String setPattern(JDBCType _jdbcType, String _pattern) {
-		if (!patterns.containsKey(_jdbcType)) {
+		if (!formats.containsKey(_jdbcType)) {
 			throw new IllegalArgumentException("JDBCType " + _jdbcType + " not handled");
 		}
-		return patterns.put(_jdbcType, _pattern);
+		String pat = null;
+		Format f;
+		if (_pattern == null) {
+			f = formats.put(_jdbcType, null);
+		} else {
+			f = formats.put(_jdbcType, new SimpleDateFormat(_pattern));
+		}
+		if (f instanceof SimpleDateFormat) {
+			pat = ((SimpleDateFormat)f).toPattern();
+		}
+		return pat;
 	}
 
 	/**
@@ -182,11 +249,17 @@ public class SSListItemFormat extends Format {
 	 * @param _jdbcType the JDBCTyep
 	 * @return the pattern or null
 	 */
+	@Deprecated
 	public String getPattern(JDBCType _jdbcType) {
-		if (!patterns.containsKey(_jdbcType)) {
+		if (!formats.containsKey(_jdbcType)) {
 			throw new IllegalArgumentException("JDBCType " + _jdbcType + " not handled");
 		}
-		return patterns.get(_jdbcType);
+		String pat = null;
+		Format f = formats.get(_jdbcType);
+		if (f instanceof SimpleDateFormat) {
+			pat = ((SimpleDateFormat)f).toPattern();
+		}
+		return pat;
 	}
 
 	/**
@@ -204,12 +277,24 @@ public class SSListItemFormat extends Format {
 		return separator;
 	}
 	
+	/**
+	 * @param source
+	 * @param pos
+	 * @return
+	 */
 	@Override
 	public Object parseObject(String source, ParsePosition pos) {
 		// Do not create objects from here
 		return source;
 	}
 	
+	/**
+	 * Note that pos is ignored. (at least for now)
+	 * @param _listItem
+	 * @param toAppendTo
+	 * @param pos
+	 * @return
+	 */
 	@Override
 	public StringBuffer format(Object _listItem, StringBuffer toAppendTo, FieldPosition pos) {
 		if (_listItem != null && _listItem instanceof ListItem0) {
@@ -235,25 +320,27 @@ public class SSListItemFormat extends Format {
 	 */
 	protected void appendValue(StringBuffer _sb, int _elemIndex, ListItem0 _listItem) {
 		Object elem = _listItem.getElem(_elemIndex);
-		JDBCType jdbcType = elemTypes.get(_elemIndex);
-		switch(jdbcType) {
-		case DATE:
-		case TIME:
-		case TIMESTAMP:
-			String pattern = patterns.get(jdbcType);
-			if (pattern != null && elem != null) {
-				SimpleDateFormat dateFormat = new SimpleDateFormat(pattern);
-				dateFormat.format(elem, _sb, FP0);
-			} else if(elem != null){
-				_sb.append(elem.toString());
-			}
-			break;
-		default:
-			if(elem != null) {
-				_sb.append(elem.toString());
-			}
-			break;
+		if (elem == null) {
+			return;
 		}
+		
+		ElemInfo elemInfo = elemInfos.get(_elemIndex);
+		JDBCType jdbcType = elemInfo.type;
+		Format format = elemInfo.format;
+		if (format == null) {
+			format = formats.get(jdbcType);
+		}
+		if (format != null) {
+			try {
+				format.format(elem, _sb, FP0);
+				return;
+			} catch (Exception ex) {
+				logger.error(String.format("can't format %s with %s. Exception: %s",
+						elem.toString(), format.toString(), ex.getMessage()));
+			}
+		}
+		// No formatter, or formatter got an exception
+		_sb.append(elem.toString());
 	}
 	
 }

--- a/swingset/src/test/java/com/nqadmin/swingset/models/SSListItemFormatTest.java
+++ b/swingset/src/test/java/com/nqadmin/swingset/models/SSListItemFormatTest.java
@@ -41,6 +41,11 @@ import java.sql.Date;
 import java.sql.JDBCType;
 import java.sql.Time;
 import java.sql.Timestamp;
+import java.text.DecimalFormat;
+import java.text.FieldPosition;
+import java.text.Format;
+import java.text.ParsePosition;
+import java.text.SimpleDateFormat;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -53,6 +58,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
@@ -88,8 +94,9 @@ public class SSListItemFormatTest {
 
 		// 5 items in listItem
 		LI listInfo = new LI(5, itemList);
-		listItem = listInfo.createListItem(integer, string, date, time, timestamp);
-		fmt = new SSListItemFormat();
+
+		listItemOld = listInfo.createListItem(integer, string, date, time, timestamp);
+		fmtOld = new SSListItemFormat();
 	}
 	
 	@AfterEach
@@ -112,6 +119,7 @@ public class SSListItemFormatTest {
 	}
 
 	String string = "everything";
+	Float floatnum =  (float)3.14159;
 	Integer integer = 42;
 	Date date;
 	Time time;
@@ -120,47 +128,224 @@ public class SSListItemFormatTest {
 	SSListItem listItem;
 	SSListItemFormat fmt;
 
+	SSListItem listItemOld;
+	SSListItemFormat fmtOld;
+
 	/**
 	 * Test of format method, of class SSListItemFormat.
 	 * 
 	 * This is the only test method, and it tests a superclass method
 	 */
 	@Test
+	@SuppressWarnings("UseOfSystemOutOrSystemErr")
 	public void testFormat() {
-		System.out.println("format");
+		System.out.print("format");
+
+		List<SSListItem> itemList = new ArrayList<>();
+		LI listInfo = new LI(5, itemList);
+		listItem = listInfo.createListItem(integer, floatnum, date, time, timestamp);
+		fmt = new SSListItemFormat();
 
 		// format everything in the list item
 		fmt.clear();
 		fmt.addElemType(0, JDBCType.INTEGER);
-		fmt.addElemType(1, JDBCType.VARCHAR);
+		fmt.addElemType(1, JDBCType.FLOAT);
 		fmt.addElemType(2, JDBCType.DATE);
 		fmt.addElemType(3, JDBCType.TIME);
 		fmt.addElemType(4, JDBCType.TIMESTAMP);
 		String format = fmt.format(listItem);
+		String expect = "42 | 3.14159 | 2021/02/13 | 04:25:26 | 2023/04/15T07:38:39";
+		assertEquals(expect, format);
+
+		// use toString by setting null
+		fmt.setFormat(JDBCType.DATE, null);
+		fmt.setFormat(JDBCType.TIME, null);
+		fmt.setFormat(JDBCType.TIMESTAMP, null);
+		format = fmt.format(listItem);
+		expect = "42 | 3.14159 | 2021-02-13 | 04:25:26 | 2023-04-15 07:38:39.0";
+		assertEquals(expect, format);
+
+		// change the order elements get formatted
+		// leave something out
+		// different format pattern
+		fmt.setFormat(JDBCType.DATE,      new SimpleDateFormat("YY"));
+		fmt.setFormat(JDBCType.TIME,      new SimpleDateFormat("HH"));
+		fmt.setFormat(JDBCType.TIMESTAMP, new SimpleDateFormat("YY*HH"));
+		fmt.setSeparator(" @@@ ");
+		fmt.clear();
+		fmt.addElemType(4, JDBCType.TIMESTAMP);
+		fmt.addElemType(1, JDBCType.FLOAT);
+		fmt.addElemType(3, JDBCType.TIME);
+		fmt.addElemType(2, JDBCType.DATE);
+		format = fmt.format(listItem);
+		expect = "23*07 @@@ 3.14159 @@@ 04 @@@ 21";
+		assertEquals(expect, format);
+
+		// change the order elements get formatted
+		// leave something out
+		// different format
+		// format for INTEGER and FLOAT
+
+		fmt.setFormat(JDBCType.INTEGER, new DecimalFormat("$#0000.00"));
+		fmt.setFormat(JDBCType.FLOAT, new DecimalFormat(".00"));
+		fmt.setFormat(JDBCType.DATE,      new SimpleDateFormat("YY"));
+		fmt.setFormat(JDBCType.TIME,      new SimpleDateFormat("HH"));
+		fmt.setFormat(JDBCType.TIMESTAMP, new SimpleDateFormat("YY*HH"));
+		fmt.setSeparator(" @@@ ");
+		fmt.clear();
+		fmt.addElemType(4, JDBCType.TIMESTAMP);
+		fmt.addElemType(1, JDBCType.FLOAT);
+		fmt.addElemType(0, JDBCType.INTEGER);
+		fmt.addElemType(2, JDBCType.DATE);
+		format = fmt.format(listItem);
+		expect = "23*07 @@@ 3.14 @@@ $0042.00 @@@ 21";
+		assertEquals(expect, format);
+
+		// add element format to override the default
+		fmt.clear();
+		fmt.addElemType(4, JDBCType.TIMESTAMP);
+		fmt.addElemType(1, JDBCType.FLOAT, new DecimalFormat(".0000"));
+		fmt.addElemType(0, JDBCType.INTEGER, new DecimalFormat("$.00"));
+		fmt.addElemType(2, JDBCType.DATE);
+		format = fmt.format(listItem);
+		expect = "23*07 @@@ 3.1416 @@@ $42.00 @@@ 21";
+		assertEquals(expect, format);
+
+		// Check exceptions in Format are handled.
+		Format exceptionFormat = new Format() {
+			@Override
+			public StringBuffer format(Object obj, StringBuffer toAppendTo, FieldPosition pos) {
+				throw new UnsupportedOperationException("Not supported yet.");
+			}
+
+			@Override
+			public Object parseObject(String source, ParsePosition pos) {
+				throw new UnsupportedOperationException("Not supported yet.");
+			}
+		};
+		// NOTE: TIMESTAMP is formatted with toString()
+		// because of exception
+		fmt.clear();
+		fmt.addElemType(4, JDBCType.TIMESTAMP, exceptionFormat);
+		fmt.addElemType(1, JDBCType.FLOAT, new DecimalFormat(".0000"));
+		fmt.addElemType(0, JDBCType.INTEGER, new DecimalFormat("$.00"));
+		fmt.addElemType(2, JDBCType.DATE);
+		format = fmt.format(listItem);
+		// TIMESTAMP formatted with toString().
+		expect = "2023-04-15 07:38:39.0 @@@ 3.1416 @@@ $42.00 @@@ 21";
+		assertEquals(expect, format);
+
+		// Get an exception from the date formatter
+		listItem = listInfo.createListItem(true, null, null, null, null);
+		fmt.clear();
+		fmt.addElemType(0, JDBCType.TIMESTAMP);
+		format = fmt.format(listItem);
+		expect = "true";
+		assertEquals(expect, format);
+	}
+	/**
+	 * Test of setDatePattern method, of class SSListItemFormat.
+	 */
+	@Test
+	@SuppressWarnings({"UseOfSystemOutOrSystemErr", "ThrowableResultIgnored"})
+	public void testSetPattern() {
+		System.out.print("setDatePattern");
+		SSListItemFormat fmt1 = new SSListItemFormat();
+
+		// check initial patterns
+		// by setting new pattern
+		// and the retrun value is the previous pattern
+		String previousPat;
+
+		previousPat = ((SimpleDateFormat)fmt1.setFormat(JDBCType.DATE, null)).toPattern();
+		assertEquals(SSListItemFormat.dateDefault, previousPat);
+		previousPat = ((SimpleDateFormat)fmt1.setFormat(JDBCType.TIME, null)).toPattern();
+		assertEquals(SSListItemFormat.timeDefault, previousPat);
+		previousPat = ((SimpleDateFormat)fmt1.setFormat(JDBCType.TIMESTAMP, null)).toPattern();
+		assertEquals(SSListItemFormat.timestampDefault, previousPat);
+	}
+
+	/**
+	 * Test of getPattern method, of class SSListItemFormat.
+	 */
+	@Test
+	@SuppressWarnings("UseOfSystemOutOrSystemErr")
+	public void testGetPattern() {
+		System.out.print("getDatePattern");
+		SSListItemFormat fmt1 = new SSListItemFormat();
+
+		// check initial patterns
+		// by getting the patterns
+		Format currentFormat;
+
+		currentFormat = fmt1.getFormat(JDBCType.DATE);
+		assertEquals(new SimpleDateFormat(SSListItemFormat.dateDefault),
+					 currentFormat);
+		currentFormat = fmt1.getFormat(JDBCType.TIME);
+		assertEquals(new SimpleDateFormat(SSListItemFormat.timeDefault),
+					 currentFormat);
+		currentFormat = fmt1.getFormat(JDBCType.TIMESTAMP);
+		assertEquals(new SimpleDateFormat(SSListItemFormat.timestampDefault),
+					 currentFormat);
+
+		// set some arbitrary strings and read them back
+		Format f1 = new SimpleDateFormat("yyyy");
+		Format f2 = new SimpleDateFormat("HH");
+		Format f3 = new SimpleDateFormat("MM");
+		fmt1.setFormat(JDBCType.DATE, f1);
+		fmt1.setFormat(JDBCType.TIME, f2);
+		fmt1.setFormat(JDBCType.TIMESTAMP, f3);
+
+		currentFormat = fmt1.getFormat(JDBCType.DATE);
+		assertEquals(currentFormat, f1);
+		currentFormat = fmt1.getFormat(JDBCType.TIME);
+		assertEquals(currentFormat, f2);
+		currentFormat = fmt1.getFormat(JDBCType.TIMESTAMP);
+		assertEquals(currentFormat, f3);
+	}
+
+	/**
+	 * Test of format method, of class SSListItemFormat.
+	 * 
+	 * This is the only test method, and it tests a superclass method
+	 */
+	@Test
+	@SuppressWarnings({"deprecation", "UseOfSystemOutOrSystemErr"})
+	public void testFormatDeprecated() {
+		System.out.print("formatDeprecated");
+
+		// format everything in the list item
+		fmtOld.clear();
+		fmtOld.addElemType(0, JDBCType.INTEGER);
+		fmtOld.addElemType(1, JDBCType.VARCHAR);
+		fmtOld.addElemType(2, JDBCType.DATE);
+		fmtOld.addElemType(3, JDBCType.TIME);
+		fmtOld.addElemType(4, JDBCType.TIMESTAMP);
+		String format = fmtOld.format(listItemOld);
 		String expect = "42 | everything | 2021/02/13 | 04:25:26 | 2023/04/15T07:38:39";
 		assertEquals(expect, format);
 
 		// use toString by setting null
-		fmt.setPattern(JDBCType.DATE, null);
-		fmt.setPattern(JDBCType.TIME, null);
-		fmt.setPattern(JDBCType.TIMESTAMP, null);
-		format = fmt.format(listItem);
+		fmtOld.setPattern(JDBCType.DATE, null);
+		fmtOld.setPattern(JDBCType.TIME, null);
+		fmtOld.setPattern(JDBCType.TIMESTAMP, null);
+		format = fmtOld.format(listItemOld);
 		expect = "42 | everything | 2021-02-13 | 04:25:26 | 2023-04-15 07:38:39.0";
 		assertEquals(expect, format);
 
 		// change the order elements get formatted
 		// leave something out
 		// different format pattern
-		fmt.setPattern(JDBCType.DATE, "YY");
-		fmt.setPattern(JDBCType.TIME, "HH");
-		fmt.setPattern(JDBCType.TIMESTAMP, "YY*HH");
-		fmt.setSeparator(" @@@ ");
-		fmt.clear();
-		fmt.addElemType(4, JDBCType.TIMESTAMP);
-		fmt.addElemType(1, JDBCType.VARCHAR);
-		fmt.addElemType(3, JDBCType.TIME);
-		fmt.addElemType(2, JDBCType.DATE);
-		format = fmt.format(listItem);
+		fmtOld.setPattern(JDBCType.DATE, "YY");
+		fmtOld.setPattern(JDBCType.TIME, "HH");
+		fmtOld.setPattern(JDBCType.TIMESTAMP, "YY*HH");
+		fmtOld.setSeparator(" @@@ ");
+		fmtOld.clear();
+		fmtOld.addElemType(4, JDBCType.TIMESTAMP);
+		fmtOld.addElemType(1, JDBCType.VARCHAR);
+		fmtOld.addElemType(3, JDBCType.TIME);
+		fmtOld.addElemType(2, JDBCType.DATE);
+		format = fmtOld.format(listItemOld);
 		expect = "23*07 @@@ everything @@@ 04 @@@ 21";
 		assertEquals(expect, format);
 	}
@@ -168,8 +353,9 @@ public class SSListItemFormatTest {
 	 * Test of setDatePattern method, of class SSListItemFormat.
 	 */
 	@Test
-	public void testSetPattern() {
-		System.out.println("setDatePattern");
+	@SuppressWarnings({"deprecation", "UseOfSystemOutOrSystemErr", "ThrowableResultIgnored"})
+	public void testSetPatternDeprecated() {
+		System.out.print("setDatePatternDeprecated");
 		SSListItemFormat fmt1 = new SSListItemFormat();
 
 		assertThrows(IllegalArgumentException.class,
@@ -192,8 +378,9 @@ public class SSListItemFormatTest {
 	 * Test of getPattern method, of class SSListItemFormat.
 	 */
 	@Test
-	public void testGetPattern() {
-		System.out.println("getDatePattern");
+	@SuppressWarnings({"deprecation", "UseOfSystemOutOrSystemErr", "ThrowableResultIgnored"})
+	public void testGetPatternDeprecated() {
+		System.out.print("getDatePatternDeprecated");
 		SSListItemFormat fmt1 = new SSListItemFormat();
 
 		assertThrows(IllegalArgumentException.class,
@@ -211,16 +398,16 @@ public class SSListItemFormatTest {
 		assertEquals(SSListItemFormat.timestampDefault, currentPattern);
 
 		// set some arbitrary strings and read them back
-		fmt1.setPattern(JDBCType.DATE, "date");
-		fmt1.setPattern(JDBCType.TIME, "time");
-		fmt1.setPattern(JDBCType.TIMESTAMP, "timestamp");
+		fmt1.setPattern(JDBCType.DATE, "yyyy");
+		fmt1.setPattern(JDBCType.TIME, "HH");
+		fmt1.setPattern(JDBCType.TIMESTAMP, "MM");
 
 		currentPattern = fmt1.getPattern(JDBCType.DATE);
-		assertEquals(currentPattern, "date");
+		assertEquals(currentPattern, "yyyy");
 		currentPattern = fmt1.getPattern(JDBCType.TIME);
-		assertEquals(currentPattern, "time");
+		assertEquals(currentPattern, "HH");
 		currentPattern = fmt1.getPattern(JDBCType.TIMESTAMP);
-		assertEquals(currentPattern, "timestamp");
+		assertEquals(currentPattern, "MM");
 	}
 
 	// /**


### PR DESCRIPTION
This PR adds these features
- Each JDBCType can have a default Format
- Each SSListItem element can have Format

The use of a format string is deprecated (it still works, now built on the new Format mechanisms). Previously only the data/time types could have a format string; everything else was toString().

Here's some examples from the unit tests 
```src/test/java/com/nqadmin/swingset/models/SSListItemFormatTest.java```

Specifying defaults for a given jdbc type.
```
fmt.setFormat(JDBCType.INTEGER, new DecimalFormat("$#0000.00"));
fmt.setFormat(JDBCType.FLOAT, new DecimalFormat(".00"));
fmt.setFormat(JDBCType.DATE,      new SimpleDateFormat("YY"));
fmt.setFormat(JDBCType.TIMESTAMP, new SimpleDateFormat("YY*HH"));
...
expect = "23*07 @@@ 3.14 @@@ $0042.00 @@@ 21";

```

And overriding the defaults for SSListItem elements 0 and 1.
```
// add element format to override the default
fmt.clear();
fmt.addElemType(4, JDBCType.TIMESTAMP);
fmt.addElemType(1, JDBCType.FLOAT, new DecimalFormat(".0000"));
fmt.addElemType(0, JDBCType.INTEGER, new DecimalFormat("$.00"));
fmt.addElemType(2, JDBCType.DATE);
format = fmt.format(listItem);
expect = "23*07 @@@ 3.1416 @@@ $42.00 @@@ 21";
```
