### PR TITLE
Default combo SSListItemFormat shows Mapping if null Option.

### DIFF
--- a/.settings/org.eclipse.core.resources.prefs
+++ b/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/swingset-demo/src/main/java/com/nqadmin/swingset/demo/Example4.java
+++ b/swingset-demo/src/main/java/com/nqadmin/swingset/demo/Example4.java
@@ -45,10 +45,8 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 
 import javax.sql.RowSet;
-import javax.swing.JComponent;
 import javax.swing.JFrame;
 import javax.swing.JLabel;
-import javax.swing.KeyStroke;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -60,8 +58,6 @@ import com.nqadmin.swingset.SSDBNavImpl;
 import com.nqadmin.swingset.SSDataNavigator;
 import com.nqadmin.swingset.SSTextField;
 import com.nqadmin.swingset.utils.SSSyncManager;
-import javax.swing.Action;
-import javax.swing.JButton;
 
 /**
  * This example displays data from the part_data table.
@@ -84,7 +80,7 @@ public class Example4 extends JFrame {
 	/**
 	 * Log4j2 Logger
 	 */
-    private static final Logger logger = LogManager.getLogger(Example4.class);
+    static final Logger logger = LogManager.getLogger(Example4.class);
 
 	/**
 	 * unique serial id
@@ -269,7 +265,12 @@ public class Example4 extends JFrame {
 				}
 
 			// SETUP THE COMBO BOX OPTIONS TO BE DISPLAYED AND THEIR CORRESPONDING VALUES
+
+				// This is the normal case, specify an option for each mapping
 				cmbPartColor.setOptions(new String[] { "Red", "Green", "Blue" });
+
+				// This is used to initialize some stuff for Example4Advanced
+				cmbPartColorChangeOptions();
 
 			// BIND THE COMPONENTS TO THE DATABASE COLUMNS
 				txtPartID.bind(rowset, "part_id");
@@ -308,8 +309,8 @@ public class Example4 extends JFrame {
 
 			// SETUP THE CONTAINER AND LAYOUT THE COMPONENTS
 				final Container contentPane = getContentPane();
-				contentPane.setLayout(new GridBagLayout());
 				final GridBagConstraints constraints = new GridBagConstraints();
+				contentPane.setLayout(new GridBagLayout());
 
 				constraints.gridx = 0;
 				constraints.gridy = 0;
@@ -347,47 +348,13 @@ public class Example4 extends JFrame {
 				constraints.gridy = 7;
 				constraints.gridwidth = 1;
 				
-			// Illustrate use of InputMap/ActionMap for custom key and extra button handling.
-			// Setup F3-F11 mnemonics to correspond to the buttons on Navigator.
-			// There are also two new buttons below the Navigator (extra first and last)
-			//
-			// The actions here are currently the only Actions available in the SSDataNavigator
-			// ActionMap.
-			//
-			// See https://docs.oracle.com/javase/tutorial/uiswing/misc/action.html
-				
-			// Hotkeys/mnemonics
-				navigator.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(KeyStroke.getKeyStroke("F3"),"NavFirst");
-				navigator.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(KeyStroke.getKeyStroke("F4"),"NavPrevious");
-				navigator.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(KeyStroke.getKeyStroke("F5"),"NavNext");
-				navigator.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(KeyStroke.getKeyStroke("F6"),"NavLast");
-				navigator.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(KeyStroke.getKeyStroke("F7"),"NavCommit");
-				navigator.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(KeyStroke.getKeyStroke("F8"),"NavUndo");
-				navigator.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(KeyStroke.getKeyStroke("F9"),"NavRefresh");
-				navigator.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(KeyStroke.getKeyStroke("F10"),"NavAdd");
-				navigator.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(KeyStroke.getKeyStroke("F11"),"NavDelete");
-				
-			// "Extra" buttons
-				Action tmpAction;
-				JButton tmpButton;
-
-				// First record
-				tmpAction = navigator.getActionMap().get("NavFirst");
-				tmpButton = new JButton(tmpAction);
-				constraints.gridx = 0;
-				contentPane.add(tmpButton, constraints);
-				
-				// Last record
-				tmpAction = navigator.getActionMap().get("NavLast");
-				tmpButton = new JButton(tmpAction);
-				constraints.gridx = 1;
-				contentPane.add(tmpButton, constraints);
-
 			// DISABLE THE PRIMARY KEY
 				txtPartID.setEnabled(false);
-	
+
 			// MAKE THE JFRAME VISIBLE
 				setVisible(true);
 				pack();
 			}
+
+	void cmbPartColorChangeOptions() {};
 }

--- a/swingset-demo/src/main/java/com/nqadmin/swingset/demo/Example4.java
+++ b/swingset-demo/src/main/java/com/nqadmin/swingset/demo/Example4.java
@@ -356,5 +356,5 @@ public class Example4 extends JFrame {
 				pack();
 			}
 
-	void cmbPartColorChangeOptions() {};
+	void cmbPartColorChangeOptions() {}
 }

--- a/swingset-demo/src/main/java/com/nqadmin/swingset/demo/Example4Advanced.java
+++ b/swingset-demo/src/main/java/com/nqadmin/swingset/demo/Example4Advanced.java
@@ -201,7 +201,7 @@ public class Example4Advanced extends Example4 {
 					public void insertString(DocumentFilter.FilterBypass fb,
 							int offset, String string, AttributeSet attr)
 							throws BadLocationException {
-						if(checkText(fb, offset, 0, string, attr))
+						if(checkText(fb, offset, 0, string))
 							super.insertString(fb, offset, string, attr);
 					}
 					
@@ -209,13 +209,13 @@ public class Example4Advanced extends Example4 {
 					public void replace(DocumentFilter.FilterBypass fb,
 							int offset, int length, String text, AttributeSet attrs)
 							throws BadLocationException {
-						if(checkText(fb, offset, length, text, attrs))
+						if(checkText(fb, offset, length, text))
 							super.replace(fb, offset, length, text, attrs);
 					}
 					
 					/** return true to proceed with action */
 					boolean checkText(FilterBypass fb,
-							int offset, int length, String text, AttributeSet attrs)
+							int offset, int length, String text)
 							throws BadLocationException {
 						Document doc01 = fb.getDocument();
 						String newText = doc01.getText(0, offset) + text

--- a/swingset-demo/src/main/java/com/nqadmin/swingset/demo/Example4Advanced.java
+++ b/swingset-demo/src/main/java/com/nqadmin/swingset/demo/Example4Advanced.java
@@ -77,6 +77,11 @@ public class Example4Advanced extends Example4 {
 		cmbPartColor.setOptions(new String[] { "Green" }, new int[] {1});
 	}
 
+	/**
+	 * Constructor for Example4Advanced
+	 * <p>
+	 * @param _dbConn - database connection
+	 */
 	public Example4Advanced(Connection _dbConn) {
 		super(_dbConn);
 
@@ -176,7 +181,7 @@ public class Example4Advanced extends Example4 {
 		// a problem using a new feature, setListItemFormat, after the
 		// combobox is fully initialized.
 
-		// Test that chaning ListItemFormat redraws the combo.
+		// Test that changing ListItemFormat redraws the combo.
 		// Change the formatter when first char of txtPartName set to '***'
 
 		// *******************************************************************
@@ -185,7 +190,7 @@ public class Example4Advanced extends Example4 {
 		// *******************************************************************
 		if(Boolean.TRUE) {
 			// Use this to demonstrate a failure.
-			// Forces the row to be updated changes collor to null
+			// Forces the row to be updated changes color to null
 			// if the current row has a missing option
 			AbstractDocument doc = (AbstractDocument) txtPartName.getDocument();
 			// both branches show the same failure mode.
@@ -242,7 +247,7 @@ public class Example4Advanced extends Example4 {
 	}
 
 	private int countChange = 2;
-	// Test that chaning ListItemFormat redraws the combo
+	// Test that changing ListItemFormat redraws the combo
 	private void changeListFormatter(String tag) {
 		countChange++;
 		int captureCountChange = countChange;

--- a/swingset-demo/src/main/java/com/nqadmin/swingset/demo/Example4Advanced.java
+++ b/swingset-demo/src/main/java/com/nqadmin/swingset/demo/Example4Advanced.java
@@ -225,8 +225,8 @@ public class Example4Advanced extends Example4 {
 							super.remove(fb, 0, 2);
 							changeListFormatter("2");
 							return false;
-						} else
-							return true;
+						}
+						return true;
 					}
 				});
 			} else {

--- a/swingset-demo/src/main/java/com/nqadmin/swingset/demo/Example4Advanced.java
+++ b/swingset-demo/src/main/java/com/nqadmin/swingset/demo/Example4Advanced.java
@@ -45,6 +45,7 @@ import java.awt.EventQueue;
 import java.awt.GridBagConstraints;
 import java.sql.Connection;
 import java.util.EnumSet;
+import java.util.Objects;
 import javax.swing.Action;
 import javax.swing.JButton;
 import javax.swing.JComponent;
@@ -258,7 +259,8 @@ public class Example4Advanced extends Example4 {
 				@Override
 				protected void appendValue(StringBuffer _sb, int _elemIndex, SSListItem _listItem) {
 					if (cmbPartColor.getOptionFormatIndex() == _elemIndex
-							&& getElem(_elemIndex, _listItem) == null) {
+							&& getElem(_elemIndex, _listItem) == null
+							&& !Objects.equals(cmbPartColor.getNullItem(), _listItem)) {
 						Object key = getElem(cmbPartColor.getMappingFormatIndex(), _listItem);
 						_sb.append(key != null ? key.toString() : null)
 								.append(" - change: ")

--- a/swingset-demo/src/main/java/com/nqadmin/swingset/demo/Example4Advanced.java
+++ b/swingset-demo/src/main/java/com/nqadmin/swingset/demo/Example4Advanced.java
@@ -217,10 +217,10 @@ public class Example4Advanced extends Example4 {
 					boolean checkText(FilterBypass fb,
 							int offset, int length, String text, AttributeSet attrs)
 							throws BadLocationException {
-						Document doc = fb.getDocument();
-						String newText = doc.getText(0, offset) + text
-								+ doc.getText(offset + length,
-										doc.getLength() - (offset + length));
+						Document doc01 = fb.getDocument();
+						String newText = doc01.getText(0, offset) + text
+								+ doc01.getText(offset + length,
+										doc01.getLength() - (offset + length));
 						if(newText.startsWith("***") && offset < 3) {
 							super.remove(fb, 0, 2);
 							changeListFormatter("2");

--- a/swingset-demo/src/main/java/com/nqadmin/swingset/demo/Example4Advanced.java
+++ b/swingset-demo/src/main/java/com/nqadmin/swingset/demo/Example4Advanced.java
@@ -1,0 +1,267 @@
+/* *****************************************************************************
+ * Copyright (C) 2022, Prasanth R. Pasala, Brian E. Pangburn, & The Pangburn Group
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Contributors:
+ *   Prasanth R. Pasala
+ *   Brian E. Pangburn
+ *   Diego Gil
+ *   Man "Bee" Vo
+ *   Ernie R. Rael
+ * ****************************************************************************/
+package com.nqadmin.swingset.demo;
+
+import com.nqadmin.swingset.SSBaseComboBox.MissingOptionControl;
+import com.nqadmin.swingset.models.SSListItem;
+import com.nqadmin.swingset.models.SSListItemFormat;
+import java.awt.Container;
+import java.awt.EventQueue;
+import java.awt.GridBagConstraints;
+import java.sql.Connection;
+import java.util.EnumSet;
+import javax.swing.Action;
+import javax.swing.JButton;
+import javax.swing.JComponent;
+import javax.swing.KeyStroke;
+import javax.swing.event.DocumentEvent;
+import javax.swing.event.DocumentListener;
+import javax.swing.text.AbstractDocument;
+import javax.swing.text.AttributeSet;
+import javax.swing.text.BadLocationException;
+import javax.swing.text.Document;
+import javax.swing.text.DocumentFilter;
+
+/**
+ * Demonstrate some advanced features of SSCombobox
+ * and using Navigator actions.
+ * <ul>
+ * <li>Using a custom ListItemFormat for null/missing Option</li>
+ * <li>MissingOptionControl</li>
+ * <li>Assigning navigator actions to function keys</li>
+ * <li>Buttons that invoke navigation actions</li>
+ * </ul>
+ */
+@SuppressWarnings("serial")
+public class Example4Advanced extends Example4 {
+
+	@Override
+	void cmbPartColorChangeOptions() {
+		// This method must be called from Example4 before
+		// some other initialization, like bind, SSSyncManager.
+		cmbPartColor.setOptions(new String[] { "Green", "Blue" }, new int[] {1,2});
+	}
+
+	public Example4Advanced(Connection _dbConn) {
+		super(_dbConn);
+
+		setTitle("Example4Advanced");
+
+		// NOTE: cmbPartColorChangeOptions has alread been called.
+
+		//////////////////////////////////////////////////////////////////////
+
+		// Example of using SSComboBox.setListItemFormat().
+		// Use a custom message when a null/missing Option
+		// is encountered in an SSComboBox.
+		// NOTE: the default message is "# - Option Not Found"
+		cmbPartColor.setListItemFormat(new SSListItemFormat() {
+			@Override
+			protected void appendValue(StringBuffer _sb, int _elemIndex, SSListItem _listItem) {
+				if (cmbPartColor.getOptionFormatIndex() == _elemIndex
+						&& getElem(_elemIndex, _listItem) == null) {
+					Object key = getElem(cmbPartColor.getMappingFormatIndex(), _listItem);
+					_sb.append(key != null ? key.toString() : null)
+							.append(" - BUG: MISSING OPTION");
+				} else {
+					super.appendValue(_sb, _elemIndex, _listItem);
+				}
+			}
+		});
+
+		//////////////////////////////////////////////////////////////////////
+
+		// Missing option handling has some controls.
+		// Here we just get the current value, log it and put it back;
+		// so we're still using the default handling. See javadoc as needed.
+
+		// Get previous value of MissingOptionControl
+		EnumSet<MissingOptionControl> mmc = cmbPartColor.setMissingOptionControl(
+				EnumSet.noneOf(MissingOptionControl.class));
+		// restore the default
+		cmbPartColor.setMissingOptionControl(mmc);
+
+		// With the following two lines retain the missing mapping option in list
+		// for all records, even those without a missing option.
+		//mmc.remove(MissingOptionControl.MOC_CLEANUP);
+		//cmbPartColor.setMissingOptionControl(mmc);
+
+		// log the MissingOptionControl values
+		logger.info(() -> ("MissingMappingFlags: " + mmc));
+
+
+		//////////////////////////////////////////////////////////////////////
+		
+		// Illustrate use of InputMap/ActionMap for custom key and extra button handling.
+		// Setup F3-F11 mnemonics to correspond to the buttons on Navigator.
+		// There are also two new buttons below the Navigator (extra first and last)
+		//
+		// The actions here are currently the only Actions available in the SSDataNavigator
+		// ActionMap.
+		//
+		// See https://docs.oracle.com/javase/tutorial/uiswing/misc/action.html
+			
+		// Hotkeys/mnemonics
+		navigator.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(KeyStroke.getKeyStroke("F3"),"NavFirst");
+		navigator.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(KeyStroke.getKeyStroke("F4"),"NavPrevious");
+		navigator.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(KeyStroke.getKeyStroke("F5"),"NavNext");
+		navigator.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(KeyStroke.getKeyStroke("F6"),"NavLast");
+		navigator.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(KeyStroke.getKeyStroke("F7"),"NavCommit");
+		navigator.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(KeyStroke.getKeyStroke("F8"),"NavUndo");
+		navigator.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(KeyStroke.getKeyStroke("F9"),"NavRefresh");
+		navigator.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(KeyStroke.getKeyStroke("F10"),"NavAdd");
+		navigator.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(KeyStroke.getKeyStroke("F11"),"NavDelete");
+
+		final Container contentPane = getContentPane();
+		final GridBagConstraints constraints = new GridBagConstraints();
+		
+	// "Extra" buttons
+		Action tmpAction;
+		JButton tmpButton;
+
+		// First record
+		tmpAction = navigator.getActionMap().get("NavFirst");
+		tmpButton = new JButton(tmpAction);
+		constraints.gridx = 0;
+		contentPane.add(tmpButton, constraints);
+		
+		// Last record
+		tmpAction = navigator.getActionMap().get("NavLast");
+		tmpButton = new JButton(tmpAction);
+		constraints.gridx = 1;
+		contentPane.add(tmpButton, constraints);
+
+		pack();
+
+		////////////////////////////////////////////////////////////////////
+		////////////////////////////////////////////////////////////////////
+		////////////////////////////////////////////////////////////////////
+
+		// The following is not a feature per se. It is for tracking down
+		// a problem using a new feature, setListItemFormat, after the
+		// combobox is fully initialized.
+
+		// Test that chaning ListItemFormat redraws the combo.
+		// Change the formatter when first char of txtPartName set to '***'
+
+		// *******************************************************************
+		// If set the following to TRUE, then when insert '***' at the
+		// beginning of txtPartName a setListItemFormat(new format...) is done.
+		// *******************************************************************
+		if(Boolean.TRUE) {
+			// Use this to demonstrate a failure.
+			// Forces the row to be updated changes collor to null
+			// if the current row has a missing option
+			AbstractDocument doc = (AbstractDocument) txtPartName.getDocument();
+			// both branches show the same failure mode.
+			if(Boolean.TRUE) {
+				doc.setDocumentFilter(new DocumentFilter() {
+					@Override
+					public void insertString(DocumentFilter.FilterBypass fb,
+							int offset, String string, AttributeSet attr)
+							throws BadLocationException {
+						if(checkText(fb, offset, 0, string, attr))
+							super.insertString(fb, offset, string, attr);
+					}
+					
+					@Override
+					public void replace(DocumentFilter.FilterBypass fb,
+							int offset, int length, String text, AttributeSet attrs)
+							throws BadLocationException {
+						if(checkText(fb, offset, length, text, attrs))
+							super.replace(fb, offset, length, text, attrs);
+					}
+					
+					/** return true to proceed with action */
+					boolean checkText(FilterBypass fb,
+							int offset, int length, String text, AttributeSet attrs)
+							throws BadLocationException {
+						Document doc = fb.getDocument();
+						String newText = doc.getText(0, offset) + text
+								+ doc.getText(offset + length,
+										doc.getLength() - (offset + length));
+						if(newText.startsWith("***") && offset < 3) {
+							super.remove(fb, 0, 2);
+							changeListFormatter("2");
+							return false;
+						} else
+							return true;
+					}
+				});
+			} else {
+				doc.addDocumentListener(new DocumentListener() {
+					@Override public void insertUpdate(DocumentEvent e) { check(); }
+					@Override public void removeUpdate(DocumentEvent e) { }
+					@Override public void changedUpdate(DocumentEvent e) { }
+					
+					void check() {
+						String text = txtPartName.getText();
+						if(text.startsWith("***")) {
+							EventQueue.invokeLater(() -> txtPartName.setText(text.substring(3)));
+							changeListFormatter("1");
+						}
+					}
+				});
+			}
+		}
+	}
+
+	private int countChange = 2;
+	// Test that chaning ListItemFormat redraws the combo
+	private void changeListFormatter(String tag) {
+		countChange++;
+		int captureCountChange = countChange;
+		logger.info(String.format("change%s formatter: %d", tag, countChange));
+		EventQueue.invokeLater(() -> {
+			cmbPartColor.setListItemFormat(new SSListItemFormat() {
+				@Override
+				protected void appendValue(StringBuffer _sb, int _elemIndex, SSListItem _listItem) {
+					if (cmbPartColor.getOptionFormatIndex() == _elemIndex
+							&& getElem(_elemIndex, _listItem) == null) {
+						Object key = getElem(cmbPartColor.getMappingFormatIndex(), _listItem);
+						_sb.append(key != null ? key.toString() : null)
+								.append(" - change: ")
+								.append(captureCountChange);
+					} else {
+						super.appendValue(_sb, _elemIndex, _listItem);
+					}
+				}
+			});
+		});
+	}
+}

--- a/swingset-demo/src/main/java/com/nqadmin/swingset/demo/Example4Advanced.java
+++ b/swingset-demo/src/main/java/com/nqadmin/swingset/demo/Example4Advanced.java
@@ -74,7 +74,8 @@ public class Example4Advanced extends Example4 {
 	void cmbPartColorChangeOptions() {
 		// This method must be called from Example4 before
 		// some other initialization, like bind, SSSyncManager.
-		cmbPartColor.setOptions(new String[] { "Green" }, new int[] {1});
+		cmbPartColor.setOptions(new String[] { "Green", "Blue" }, new int[] {1,2});
+		//cmbPartColor.setOptions(new String[] { "Yellow", "Purple" }, new int[] {3,4});
 	}
 
 	/**

--- a/swingset-demo/src/main/java/com/nqadmin/swingset/demo/Example4Advanced.java
+++ b/swingset-demo/src/main/java/com/nqadmin/swingset/demo/Example4Advanced.java
@@ -74,13 +74,13 @@ public class Example4Advanced extends Example4 {
 	void cmbPartColorChangeOptions() {
 		// This method must be called from Example4 before
 		// some other initialization, like bind, SSSyncManager.
-		cmbPartColor.setOptions(new String[] { "Green", "Blue" }, new int[] {1,2});
+		cmbPartColor.setOptions(new String[] { "Green" }, new int[] {1});
 	}
 
 	public Example4Advanced(Connection _dbConn) {
 		super(_dbConn);
 
-		setTitle("Example4Advanced");
+		setTitle("Example4 Advanced");
 
 		// NOTE: cmbPartColorChangeOptions has alread been called.
 

--- a/swingset-demo/src/main/java/com/nqadmin/swingset/demo/MainClass.java
+++ b/swingset-demo/src/main/java/com/nqadmin/swingset/demo/MainClass.java
@@ -111,7 +111,7 @@ public class MainClass extends JFrame {
 				new Example4Advanced(dbConnection);
 			} else if (ae.getSource().equals(btnExample4UsingHelper)) {
 				logger.debug("**** Opening Example4UsingHelper ****");
-				JFrame e4JFrame = new JFrame("Example4UsingHelper");
+				JFrame e4JFrame = new JFrame("Example4 Using Helper");
 				e4JFrame.setLocation(DemoUtil.getChildScreenLocation("Example4UsingHelper"));
 				Example4UsingHelper example4 = new Example4UsingHelper(dbConnection, e4JFrame);
 				e4JFrame.add(example4);
@@ -130,7 +130,7 @@ public class MainClass extends JFrame {
 				new Example7(dbConnection);
 			} else if (ae.getSource().equals(btnExample7UsingHelper)) {
 				logger.debug("**** Opening Example7UsingHelper ****");
-				JFrame e7JFrame = new JFrame("Example7UsingHelper");
+				JFrame e7JFrame = new JFrame("Example7 Using Helper");
 				Example7UsingHelper example7 = new Example7UsingHelper(dbConnection, null);
 				e7JFrame.add(example7);
 				e7JFrame.setLocation(DemoUtil.getChildScreenLocation("Example7UsingHelper"));
@@ -207,7 +207,7 @@ public class MainClass extends JFrame {
 	private JButton btnExample2 = new JButton("Example2");
 	private JButton btnExample3 = new JButton("Example3");
 	private JButton btnExample4 = new JButton("Example4");
-	private JButton btnExample4Advanced = new JButton("Example4Advanced");
+	private JButton btnExample4Advanced = new JButton("Example4 Advanced");
 	private JButton btnExample4UsingHelper = new JButton("Example4 Using Helper");
 	private JButton btnExample5 = new JButton("Example5");
 	private JButton btnExample6 = new JButton("Example6");

--- a/swingset-demo/src/main/java/com/nqadmin/swingset/demo/MainClass.java
+++ b/swingset-demo/src/main/java/com/nqadmin/swingset/demo/MainClass.java
@@ -106,6 +106,9 @@ public class MainClass extends JFrame {
 			} else if (ae.getSource().equals(btnExample4)) {
 				logger.debug("**** Opening Example4 ****");
 				new Example4(dbConnection);
+			} else if (ae.getSource().equals(btnExample4Advanced)) {
+				logger.debug("**** Opening Example4Advanced ****");
+				new Example4Advanced(dbConnection);
 			} else if (ae.getSource().equals(btnExample4UsingHelper)) {
 				logger.debug("**** Opening Example4UsingHelper ****");
 				JFrame e4JFrame = new JFrame("Example4UsingHelper");
@@ -204,6 +207,7 @@ public class MainClass extends JFrame {
 	private JButton btnExample2 = new JButton("Example2");
 	private JButton btnExample3 = new JButton("Example3");
 	private JButton btnExample4 = new JButton("Example4");
+	private JButton btnExample4Advanced = new JButton("Example4Advanced");
 	private JButton btnExample4UsingHelper = new JButton("Example4 Using Helper");
 	private JButton btnExample5 = new JButton("Example5");
 	private JButton btnExample6 = new JButton("Example6");
@@ -254,6 +258,7 @@ public class MainClass extends JFrame {
 		btnExample2.addActionListener(new MyButtonListener());
 		btnExample3.addActionListener(new MyButtonListener());
 		btnExample4.addActionListener(new MyButtonListener());
+		btnExample4Advanced.addActionListener(new MyButtonListener());
 		btnExample4UsingHelper.addActionListener(new MyButtonListener());
 		btnExample5.addActionListener(new MyButtonListener());
 		btnExample6.addActionListener(new MyButtonListener());
@@ -268,6 +273,7 @@ public class MainClass extends JFrame {
 		btnExample2.setPreferredSize(buttonDim);
 		btnExample3.setPreferredSize(buttonDim);
 		btnExample4.setPreferredSize(buttonDim);
+		btnExample4Advanced.setPreferredSize(buttonDim);
 		btnExample4UsingHelper.setPreferredSize(buttonDim);
 		btnExample5.setPreferredSize(buttonDim);
 		btnExample6.setPreferredSize(buttonDim);
@@ -283,6 +289,7 @@ public class MainClass extends JFrame {
 		getContentPane().add(btnExample2);
 		getContentPane().add(btnExample3);
 		getContentPane().add(btnExample4);
+		getContentPane().add(btnExample4Advanced);
 		getContentPane().add(btnExample4UsingHelper);
 		getContentPane().add(btnExample5);
 		getContentPane().add(btnExample6);

--- a/swingset/pom.xml
+++ b/swingset/pom.xml
@@ -246,7 +246,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>${version.maven-compiler-plugin}</version>
+				<version>${version.maven-compiler-plugin}</version><!--$NO-MVN-MAN-VER$-->
 
 				<configuration>
 					<source>${version.java}</source>

--- a/swingset/src/main/java/com/nqadmin/swingset/SSBaseComboBox.java
+++ b/swingset/src/main/java/com/nqadmin/swingset/SSBaseComboBox.java
@@ -468,7 +468,7 @@ public abstract class SSBaseComboBox<M,O,O2> extends JComboBox<SSListItem> imple
 
 	/**
 	 * create SSBaseComboBox
-	 * @param useGlazed
+	 * @param useGlazed use glazedlists
 	 */
 	@SuppressWarnings("LeakingThisInConstructor")
 	public SSBaseComboBox(boolean useGlazed) {
@@ -839,7 +839,7 @@ public abstract class SSBaseComboBox<M,O,O2> extends JComboBox<SSListItem> imple
 	 * from the database is encountered and no Option was specified,
 	 * a combobox list entry is created for the Mapping with null option;
 	 * a custom message, see
- 	 * {@link #setListItemFormat(com.nqadmin.swingset.models.SSListItemFormat),
+ 	 * {@link #setListItemFormat(com.nqadmin.swingset.models.SSListItemFormat)},
 	 * may be setup for handling these entries for the combobox display.
 	 * If {@code MOC_CLEANUP} then when the combobox navigates away
 	 * from a record with a missing option, the automatically created

--- a/swingset/src/main/java/com/nqadmin/swingset/SSBaseComboBox.java
+++ b/swingset/src/main/java/com/nqadmin/swingset/SSBaseComboBox.java
@@ -347,7 +347,8 @@ public abstract class SSBaseComboBox<M,O,O2> extends JComboBox<SSListItem> imple
 		@Override
 		protected void appendValue(StringBuffer _sb, int _elemIndex, SSListItem _listItem) {
 			if (getOptionFormatIndex() == _elemIndex
-					&& getElem(_elemIndex, _listItem) == null) {
+					&& getElem(_elemIndex, _listItem) == null
+					&& !Objects.equals(getNullItem(), _listItem)) {
 				Object key = getElem(getMappingFormatIndex(), _listItem);
 				_sb.append(key != null ? key.toString() : null)
 						.append(" - Option Not Found");
@@ -1116,6 +1117,14 @@ public abstract class SSBaseComboBox<M,O,O2> extends JComboBox<SSListItem> imple
 	 * @return the created null item.
 	 */
 	protected abstract SSListItem createNullItem(BaseModel<M,O,O2>.Remodel remodel);
+
+	/**
+	 * Return this ComboBox's nullItem.
+	 * @return the nullItem
+	 */
+	public SSListItem getNullItem() {
+		return nullItem;
+	}
 
 	/**
 	 * A combobox used as a navigator has some restriction; for example,

--- a/swingset/src/main/java/com/nqadmin/swingset/SSBaseComboBox.java
+++ b/swingset/src/main/java/com/nqadmin/swingset/SSBaseComboBox.java
@@ -49,6 +49,8 @@ import java.awt.event.KeyAdapter;
 import java.awt.event.KeyEvent;
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
 
@@ -62,6 +64,7 @@ import com.nqadmin.swingset.models.AbstractComboBoxListSwingModel;
 import com.nqadmin.swingset.models.GlazedListsOptionMappingInfo;
 import com.nqadmin.swingset.models.OptionMappingSwingModel;
 import com.nqadmin.swingset.models.SSListItem;
+import com.nqadmin.swingset.models.SSListItemFormat;
 import com.nqadmin.swingset.utils.SSCommon;
 import com.nqadmin.swingset.utils.SSComponentInterface;
 import com.nqadmin.swingset.utils.SSUtils;
@@ -201,6 +204,11 @@ public abstract class SSBaseComboBox<M,O,O2> extends JComboBox<SSListItem> imple
 		{
 			//System.err.println(e.paramString());
 			if (e.getStateChange() == ItemEvent.SELECTED) {
+				// Move cleanupMissing... to updateSSComponent so that the
+				// combo list doesn't change while a row is displayed.
+				// If needed, could have a control option for when
+				// to do the cleanup.
+				// cleanupMissingMappingOptions();
 				if (getSelectedItem() != nullItem && selectionPending) {
 					setSelectionPending(false);
 					//System.err.println("itemStateChanged true --> false");
@@ -281,7 +289,7 @@ public abstract class SSBaseComboBox<M,O,O2> extends JComboBox<SSListItem> imple
 		 */
 		protected static <M,O,O2>BaseGlazedModel<M,O,O2> install(SSBaseComboBox<M,O,O2> _jc) {
 			BaseGlazedModel<M,O,O2> model = new BaseGlazedModel<>();
-			model.autoComplete = AutoCompleteSupport.install(_jc, model.getEventList(), null, model.getListItemFormat());
+			model.autoComplete = AutoCompleteSupport.install(_jc, model.getEventList(), null, model.getListItemFormatDelegate());
 			
 			model.autoComplete.setFilterMode(TextMatcherEditor.CONTAINS);
 			model.autoComplete.setStrict(true);
@@ -303,6 +311,53 @@ public abstract class SSBaseComboBox<M,O,O2> extends JComboBox<SSListItem> imple
 	}
 
 	/**
+	 * @return the mapping index in an SSListItem
+	 */
+	public int getMappingFormatIndex() {
+		return optionModel.getMappingListItemElemIndex();
+	}
+
+	/**
+	 * @return the option index in an SSListItem
+	 */
+	public int getOptionFormatIndex() {
+		return optionModel.getOptionListItemElemIndex();
+	}
+
+	/**
+	 * @return the option2 index in an SSListItem
+	 */
+	public int getOption2FormatIndex() {
+		return optionModel.getOption2ListItemElemIndex();
+	}
+
+	/**
+	 * A list item formatter that displays the mapping if the option is null.
+	 */
+	@SuppressWarnings("serial")
+	class ShowMappingIfNullOption extends SSListItemFormat {
+
+		/**
+		 * If null option, then show the mapping;
+		 * otherwise do the default formatting.
+		 * @param _sb display value goes here
+		 * @param _elemIndex which option to format
+		 * @param _listItem combobox list item
+		 */
+		@Override
+		protected void appendValue(StringBuffer _sb, int _elemIndex, SSListItem _listItem) {
+			if (getOptionFormatIndex() == _elemIndex
+					&& getElem(_elemIndex, _listItem) == null) {
+				Object key = getElem(getMappingFormatIndex(), _listItem);
+				_sb.append(key != null ? key.toString() : null)
+						.append(" - Option Not Found");
+			} else {
+				super.appendValue(_sb, _elemIndex, _listItem);
+			}
+		}
+	}
+
+	/**
 	 * Log4j Logger for component
 	 */
 	private static final Logger logger = SSUtils.getLogger();
@@ -318,7 +373,7 @@ public abstract class SSBaseComboBox<M,O,O2> extends JComboBox<SSListItem> imple
 	 * the nullItem must be set to null.</b>
 	 * @see #createNullItem(com.nqadmin.swingset.models.OptionMappingSwingModel.Remodel)
 	 */
-	protected SSListItem nullItem;
+	transient protected SSListItem nullItem;
 	
 //	/**
 //	 * String typed by user into combobox
@@ -358,7 +413,7 @@ public abstract class SSBaseComboBox<M,O,O2> extends JComboBox<SSListItem> imple
 	/**
 	 * The combo model.
 	 */
-	protected OptionMappingSwingModel<M,O,O2> optionModel;
+	transient protected OptionMappingSwingModel<M,O,O2> optionModel;
 
 	//////////////////////////////////////////////////////////////////////////
 	//
@@ -386,7 +441,9 @@ public abstract class SSBaseComboBox<M,O,O2> extends JComboBox<SSListItem> imple
 	 * Convenience method for accessing the model with proper casting.
 	 * 
 	 * @return mapping list model with proper casting, may be null
+	 * @deprecated use field optionModel directly
 	 */
+	@Deprecated
 	protected OptionMappingSwingModel<M, O, O2> getOptionModel() {
 		return optionModel;
 	}
@@ -407,6 +464,49 @@ public abstract class SSBaseComboBox<M,O,O2> extends JComboBox<SSListItem> imple
 	 */
 	public SSBaseComboBox() {
 		addItemListener(new SSBaseComboBoxItemListener());
+	}
+
+	/**
+	 * create SSBaseComboBox
+	 * @param useGlazed
+	 */
+	@SuppressWarnings("LeakingThisInConstructor")
+	public SSBaseComboBox(boolean useGlazed) {
+		this();
+
+		if (useGlazed) {
+			optionModel = BaseGlazedModel.install(this);
+		} else {
+			optionModel = BaseModel.install(this);
+		}
+		optionModel.setListItemFormat(new ShowMappingIfNullOption());
+	}
+
+	/**
+	 * Set the format to use with this model.
+	 * <br>TODO: consider deferring the actual change until row change
+	 * 
+	 * @param _listItemFormat the format used with this model
+	 */
+	public void setListItemFormat(SSListItemFormat _listItemFormat) {
+		Object selectedItem = getSelectedItem();
+		boolean keep = Objects.equals(getEditor().getItem(), selectedItem);
+		optionModel.setListItemFormat(_listItemFormat);
+		// A new format may change the target contents of the comboBox editor.
+		// When it does change, the contents of the combo editor is changed
+		// from ListItem to a String with the old value.
+		// If the combo editor held the selected item before,
+		// then it should hold the selected item after.
+		if(keep)
+			getEditor().setItem(selectedItem);
+	}
+
+	/**
+	 * Return the listItemFormat associated with this combobox.
+	 * @return the associated listItemFormat
+	 */
+	public SSListItemFormat getListItemFormat() {
+		return optionModel.getListItemFormat();
 	}
 
 
@@ -665,6 +765,98 @@ public abstract class SSBaseComboBox<M,O,O2> extends JComboBox<SSListItem> imple
 		return result;
 	}
 
+	transient private final List<M> generatedMappingOptions = new ArrayList<>();
+	private int addMissingMappingOption(BaseModel<M,O,O2>.Remodel remodel, M _mapping) {
+		int index = -1;
+		if(_mapping != null) {
+			if(missingOptionControl.contains(MissingOptionControl.MOC_ADD)) {
+				remodel.add(_mapping, null);
+				index = remodel.getMappings().indexOf(_mapping);
+				logger.debug(() -> "missingMappingOption added: " + _mapping);
+				generatedMappingOptions.add(_mapping);
+			}
+		}
+		return index;
+	}
+
+	/**
+	 * If current selection does not have a null option,
+	 * then remove any created missingMappingOptionss from list.
+	 * Must be EDT
+	 */
+	private void cleanupMissingMappingOptions() {
+		if(generatedMappingOptions.isEmpty()
+				|| !missingOptionControl.contains(MissingOptionControl.MOC_CLEANUP))
+			return;
+		if(generatedMappingOptions.size() > 1)
+			logger.warn(() -> "size: " + generatedMappingOptions.size());
+		try (BaseModel<M,O,O2>.Remodel remodel = optionModel.getRemodel()) {
+			for (Iterator<M> it = generatedMappingOptions.iterator(); it.hasNext();) {
+				M missingMappingOption = it.next();
+				// Sequential records might have different missing options;
+				// never remove a missing option for the current selected mapping.
+				if(Objects.equals(missingMappingOption, getSelectedMapping()))
+					continue;
+				int index = remodel.getMappings().indexOf(missingMappingOption);
+				if(index != -1) {
+					SSListItem removed = remodel.remove(index);
+					logger.debug(() -> "missingMappingOption removed: " + removed);
+				} else {
+					logger.warn(() -> "not in combo: " + missingMappingOption);
+				}
+				it.remove(); // it's not in the combo list anymore
+			}
+		}
+
+	}
+
+	private final EnumSet<MissingOptionControl> missingOptionControl = EnumSet.allOf(MissingOptionControl.class);
+
+	/**
+	 * Flags to control handling of Mapping, database value,
+	 * without a specified Option;
+	 * see {@link #setMissingOptionControl(java.util.EnumSet) } for
+	 * meaning of the flags.
+	 */
+	public enum MissingOptionControl {
+
+		/**
+		 * Autmatically generate list item entry
+		 * when current database record, mapping, does not have an option.
+		 */
+		MOC_ADD,
+
+		/**
+		 * Remove any auto gen entry if current database record has an option.
+		 */
+		MOC_CLEANUP;
+	}
+
+	/**
+	 * Set the flags that control how a Mapping, database value,
+	 * without a specified option is handled.
+	 * If {@code MOC_ADD} and a Mapping
+	 * from the database is encountered and no Option was specified,
+	 * a combobox list entry is created for the Mapping with null option;
+	 * a custom message, see
+ 	 * {@link #setListItemFormat(com.nqadmin.swingset.models.SSListItemFormat),
+	 * may be setup for handling these entries for the combobox display.
+	 * If {@code MOC_CLEANUP} then when the combobox navigates away
+	 * from a record with a missing option, the automatically created
+	 * list entry is removed.
+	 * <p>
+	 * Flags default to {@code MOC_ADD} and {@code MOC_CLEANUP}.
+	 * 
+	 * @param flags new value
+	 * @return previous value
+	 */
+	public EnumSet<MissingOptionControl> setMissingOptionControl(EnumSet<MissingOptionControl> flags) {
+		EnumSet<MissingOptionControl> prev = missingOptionControl.clone();
+		missingOptionControl.clear();
+		missingOptionControl.addAll(flags);
+		return prev;
+	}
+
 	/**
 	 * Sets the selected ComboBox item according to the specified mapping/key.
 	 * The selectedItem is set to nullItem or null if mapping not found.
@@ -695,9 +887,11 @@ public abstract class SSBaseComboBox<M,O,O2> extends JComboBox<SSListItem> imple
 				return;
 			}
 			
-			final int index = remodel.getMappings().indexOf(_mapping);
+			int index = remodel.getMappings().indexOf(_mapping);
 			SSListItem item;
 			if (index != -1) {
+				item = remodel.get(index);
+			} else if((index = addMissingMappingOption(remodel, _mapping)) != -1) {
 				item = remodel.get(index);
 			} else {
 				// nullItem is either special first list item
@@ -1078,9 +1272,9 @@ public abstract class SSBaseComboBox<M,O,O2> extends JComboBox<SSListItem> imple
 			if ((boundColumnText != null) && !boundColumnText.isEmpty()) {
 				// https://github.com/bpangburn/swingset/issues/46
 				if (this instanceof SSComboBox) {
-					objValue = Integer.parseInt(boundColumnText);
+					objValue = Integer.valueOf(boundColumnText);
 				} else if (this instanceof SSDBComboBox) {
-					objValue = Long.parseLong(boundColumnText);
+					objValue = Long.valueOf(boundColumnText);
 				} else {
 					throw new Exception();
 				}
@@ -1102,6 +1296,8 @@ public abstract class SSBaseComboBox<M,O,O2> extends JComboBox<SSListItem> imple
 			JOptionPane.showMessageDialog(this, String.format(
 					"Expecting SSComboBox or SSDBComboBox, but component for column [%s] is of type %s.", this.getClass(), getColumnForLog()));
 			logger.error(getColumnForLog() + ": Unknown SwingSet component of " + this.getClass() + ".", e);
+		} finally {
+			cleanupMissingMappingOptions();
 		}
 	}
 

--- a/swingset/src/main/java/com/nqadmin/swingset/SSComboBox.java
+++ b/swingset/src/main/java/com/nqadmin/swingset/SSComboBox.java
@@ -308,15 +308,8 @@ public class SSComboBox extends SSBaseComboBox<Integer, String, Object>
 	 * @param useGlazedLists install glazed lists
 	 */
 	// TODO: See if we can remove "all" in later JDK, but may be IDE-specific.
-	@SuppressWarnings({"all","LeakingThisInConstructor"})
 	public SSComboBox(boolean useGlazedLists) {
-		// Note that call to parent default constructor is implicit.
-		//super();
-		if (useGlazedLists) {
-			optionModel = GlazedModel.install(this);
-		} else {
-			optionModel = Model.install(this);
-		}
+		super(useGlazedLists);
 	}
 
 	/**

--- a/swingset/src/main/java/com/nqadmin/swingset/SSComboBox.java
+++ b/swingset/src/main/java/com/nqadmin/swingset/SSComboBox.java
@@ -50,6 +50,7 @@ import javax.swing.JComboBox;
 
 import org.apache.logging.log4j.Logger;
 
+import com.nqadmin.swingset.models.OptionMappingSwingModel;
 import com.nqadmin.swingset.models.SSListItem;
 import com.nqadmin.swingset.utils.SSUtils;
 
@@ -78,7 +79,7 @@ import com.nqadmin.swingset.utils.SSUtils;
  * not something that is based on {@code getSelectedIndex()}.
  * Change the current combo box item with methods
  * such as:
- * {@link #setSelectedMapping(java.lang.Object) setSelectedMapping(Integer)}
+ * {@link #setSelectedMapping(M) setSelectedMapping(Integer)}
  * and
  * {@link SSBaseComboBox#setSelectedOption(java.lang.Object) setSelectedOption(String)}.
  * Use the methods {@link SSBaseComboBox#hasItems() hasItems() } and
@@ -142,12 +143,10 @@ public class SSComboBox extends SSBaseComboBox<Integer, String, Object>
 {
 	private static final long serialVersionUID = 521308332266885608L;
 
-	private static class Model extends SSBaseComboBox.BaseModel<Integer, String, Object>
-	{
-	}
-
-	private static class GlazedModel extends SSBaseComboBox.BaseGlazedModel<Integer, String, Object>
-	{
+	/** A convenience for variable declarations. Can not instantiate. */
+	private static class Model extends OptionMappingSwingModel<Integer,String,Object> {
+		/** Exception if invoked. */
+		public Model() { Objects.requireNonNull(null); } 
 	}
 
 	/**

--- a/swingset/src/main/java/com/nqadmin/swingset/SSDBComboBox.java
+++ b/swingset/src/main/java/com/nqadmin/swingset/SSDBComboBox.java
@@ -82,7 +82,7 @@ import ca.odell.glazedlists.EventList;
  * not something that is based on {@code getSelectedIndex()}.
  * Change the current combo box item with methods
  * such as:
- * {@link #setSelectedMapping(java.lang.Long) setSelectedMapping(Long)}
+ * {@link #setSelectedMapping(java.lang.Object) setSelectedMapping(Long)}
  * and
  * {@link SSBaseComboBox#setSelectedOption(java.lang.Object) setSelectedOption(String)}.
  * Use the methods {@link SSBaseComboBox#hasItems() hasItems() } and

--- a/swingset/src/main/java/com/nqadmin/swingset/SSDBComboBox.java
+++ b/swingset/src/main/java/com/nqadmin/swingset/SSDBComboBox.java
@@ -51,6 +51,7 @@ import java.util.Objects;
 
 import org.apache.logging.log4j.Logger;
 
+import com.nqadmin.swingset.models.OptionMappingSwingModel;
 import com.nqadmin.swingset.models.SSListItem;
 import com.nqadmin.swingset.models.SSListItemFormat;
 import com.nqadmin.swingset.utils.SSUtils;
@@ -82,7 +83,7 @@ import ca.odell.glazedlists.EventList;
  * not something that is based on {@code getSelectedIndex()}.
  * Change the current combo box item with methods
  * such as:
- * {@link #setSelectedMapping(java.lang.Object) setSelectedMapping(Long)}
+ * {@link #setSelectedMapping(M) setSelectedMapping(Long)}
  * and
  * {@link SSBaseComboBox#setSelectedOption(java.lang.Object) setSelectedOption(String)}.
  * Use the methods {@link SSBaseComboBox#hasItems() hasItems() } and
@@ -184,12 +185,10 @@ public class SSDBComboBox extends SSBaseComboBox<Long, Object, Object>
 	@Deprecated
 	public static final int NON_SELECTED = Integer.MIN_VALUE + 1;
 
-	private static class Model extends SSBaseComboBox.BaseModel<Long, Object, Object>
-	{
-	}
-
-	private static class GlazedModel extends SSBaseComboBox.BaseGlazedModel<Long, Object, Object>
-	{
+	/** A convenience for variable declarations. Can not instantiate. */
+	private static class Model extends OptionMappingSwingModel<Long,Object,Object> {
+		/** Exception if invoked. */
+		public Model() { Objects.requireNonNull(null); } 
 	}
 
 	/**

--- a/swingset/src/main/java/com/nqadmin/swingset/SSDBComboBox.java
+++ b/swingset/src/main/java/com/nqadmin/swingset/SSDBComboBox.java
@@ -82,7 +82,7 @@ import ca.odell.glazedlists.EventList;
  * not something that is based on {@code getSelectedIndex()}.
  * Change the current combo box item with methods
  * such as:
- * {@link #setSelectedMapping(java.lang.Object) setSelectedMapping(Long)}
+ * {@link #setSelectedMapping(java.lang.Long) setSelectedMapping(Long)}
  * and
  * {@link SSBaseComboBox#setSelectedOption(java.lang.Object) setSelectedOption(String)}.
  * Use the methods {@link SSBaseComboBox#hasItems() hasItems() } and
@@ -392,7 +392,7 @@ public class SSDBComboBox extends SSBaseComboBox<Long, Object, Object>
 	 *
 	 * @param _displayText text that should be displayed in the combobox
 	 * @param _primaryKey  primary key value corresponding the the display text
-	 * @deprecated use {@link #addOption(java.lang.String, java.lang.Long) }
+	 * @deprecated use {@link #addOption(java.lang.Object, java.lang.Long) }
 	 */
 	@Deprecated
 	public void addItem(final String _displayText, final long _primaryKey) {
@@ -438,7 +438,7 @@ public class SSDBComboBox extends SSBaseComboBox<Long, Object, Object>
 	 *
 	 * @param _name  name that should be displayed in the combo
 	 * @param _value value corresponding the the name
-	 * @deprecated use {@link #addOption(java.lang.String, java.lang.Long) }
+	 * @deprecated use {@link #addOption(java.lang.Object, java.lang.Long) }
 	 */
 	@Deprecated
 	protected void addStringItem(final String _name, final String _value) {

--- a/swingset/src/main/java/com/nqadmin/swingset/SSDBComboBox.java
+++ b/swingset/src/main/java/com/nqadmin/swingset/SSDBComboBox.java
@@ -44,6 +44,7 @@ import java.sql.JDBCType;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -304,18 +305,11 @@ public class SSDBComboBox extends SSBaseComboBox<Long, Object, Object>
 	 * Creates an object of the SSDBComboBox.
 	 */
 	// TODO: See if we can remove "all" in later JDK, but may be IDE-specific.
-	@SuppressWarnings({"all","LeakingThisInConstructor"})
 	public SSDBComboBox() {
-		// Note that call to parent default constructor is implicit.
-		//super();
+		super(USE_GLAZED_MODEL);
 
-		if (USE_GLAZED_MODEL) {
-			optionModel = GlazedModel.install(this);
-		} else {
-			optionModel = Model.install(this);
-		}
-		listItemFormat = optionModel.getListItemFormat();
-		listItemFormat.setPattern(JDBCType.DATE, dateFormat);
+		listItemFormat = getListItemFormat();
+		listItemFormat.setFormat(JDBCType.DATE, new SimpleDateFormat(dateFormat));
 		listItemFormat.setSeparator(separator);
 	}
 	
@@ -1148,7 +1142,7 @@ public class SSDBComboBox extends SSBaseComboBox<Long, Object, Object>
 		final String oldValue = dateFormat;
 		dateFormat = _dateFormat;
 		firePropertyChange("dateFormat", oldValue, dateFormat);
-		listItemFormat.setPattern(JDBCType.DATE, _dateFormat);
+		listItemFormat.setFormat(JDBCType.DATE, new SimpleDateFormat(_dateFormat));
 	}
 
 	/**

--- a/swingset/src/main/java/com/nqadmin/swingset/models/AbstractComboBoxListSwingModel.java
+++ b/swingset/src/main/java/com/nqadmin/swingset/models/AbstractComboBoxListSwingModel.java
@@ -404,7 +404,7 @@ public abstract class AbstractComboBoxListSwingModel {
 			return listItemFormat != null
 					? listItemFormat.parseObject(source, pos) : source;
 		}
-	};
+	}
 
 	/**
 	 * Delegates formatting on the fly.

--- a/swingset/src/main/java/com/nqadmin/swingset/models/AbstractComboBoxListSwingModel.java
+++ b/swingset/src/main/java/com/nqadmin/swingset/models/AbstractComboBoxListSwingModel.java
@@ -41,6 +41,9 @@ import java.awt.Component;
 import java.lang.ref.WeakReference;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
+import java.text.FieldPosition;
+import java.text.Format;
+import java.text.ParsePosition;
 import java.util.AbstractList;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -226,6 +229,7 @@ public abstract class AbstractComboBoxListSwingModel {
 	
 	
 	protected AbstractComboBoxListSwingModel(int _itemNumElems, List<SSListItem> _itemList) {
+		this.listItemFormatDelegate = new FormatDelegate();
 		if(_itemList != null && !_itemList.isEmpty()) {
 			throw new IllegalArgumentException("item list must be empty");
 		}
@@ -374,7 +378,41 @@ public abstract class AbstractComboBoxListSwingModel {
 		}
 	}
 
-	private SSListItemFormat listItemFormat;
+	final private FormatDelegate listItemFormatDelegate;
+
+	/**
+	 * When used with glazed lists, the format is set at install into combo
+	 * time and can not be changed. So glazed installs FormatDelegate, and
+	 * then setItemListFormat is set/changed as convenient.
+	 * <p>
+	 * If the format is changed after combo box initialization is complete,
+	 * then it is up to the user to force the combo to redraw.
+	 */
+	@SuppressWarnings("serial")
+	private static class FormatDelegate extends Format {
+		private SSListItemFormat listItemFormat;
+
+		@Override
+		public StringBuffer format(Object obj, StringBuffer toAppendTo, FieldPosition pos) {
+			return listItemFormat != null
+					? listItemFormat.format(obj, toAppendTo, pos)
+					: toAppendTo.append(obj);
+		}
+
+		@Override
+		public Object parseObject(String source, ParsePosition pos) {
+			return listItemFormat != null
+					? listItemFormat.parseObject(source, pos) : source;
+		}
+	};
+
+	/**
+	 * Delegates formatting on the fly.
+	 * @return Format to install in the model
+	 */
+	protected Format getListItemFormatDelegate() {
+		return listItemFormatDelegate;
+	}
 
 	/**
 	 * Set the format to use with this model.
@@ -382,7 +420,12 @@ public abstract class AbstractComboBoxListSwingModel {
 	 * @param _listItemFormat the format used with this model
 	 */
 	public void setListItemFormat(SSListItemFormat _listItemFormat) {
-		listItemFormat = _listItemFormat;
+		listItemFormatDelegate.listItemFormat = _listItemFormat;
+		if(modelProxy != null && !itemList.isEmpty()) {
+			// assume everything changed
+			modelProxy.fire.doFireContentsChanged(this, 0, itemList.size() - 1);
+			modelProxy.fire.doFireContentsChanged(this, -1, -1);
+		}
 	}
 
 	/**
@@ -390,10 +433,10 @@ public abstract class AbstractComboBoxListSwingModel {
 	 * @return the associated listItemFormat
 	 */
 	public SSListItemFormat getListItemFormat() {
-		if (listItemFormat == null) {
-			listItemFormat = new SSListItemFormat();
+		if (listItemFormatDelegate.listItemFormat == null) {
+			listItemFormatDelegate.listItemFormat = new SSListItemFormat();
 		}
-		return listItemFormat;
+		return listItemFormatDelegate.listItemFormat;
 	}
 
 	/**

--- a/swingset/src/main/java/com/nqadmin/swingset/models/GlazedListsOptionMappingInfo.java
+++ b/swingset/src/main/java/com/nqadmin/swingset/models/GlazedListsOptionMappingInfo.java
@@ -46,7 +46,7 @@ import ca.odell.glazedlists.EventList;
 
 /**
  * This class adds support for GlazedLists locking,
- * see {@link Remodel}.
+ * see {@link OptionMappingSwingModel.Remodel}.
  * @param <M> mapping type; mapping is typically primary key
  * @param <O> option type; option provides display string
  * @param <O2>  option2 type; if present, supplementary display string

--- a/swingset/src/main/java/com/nqadmin/swingset/models/OptionMappingSwingModel.java
+++ b/swingset/src/main/java/com/nqadmin/swingset/models/OptionMappingSwingModel.java
@@ -111,6 +111,13 @@ public class OptionMappingSwingModel<M,O,O2> extends AbstractComboBoxListSwingMo
 	}
 
 	/**
+	 * Create an empty OptionMappingSwingModel with no options2.
+	 */
+	protected OptionMappingSwingModel() {
+		this(false);
+	}
+
+	/**
 	 * Create an empty OptionMappingSwingModel .
 	 * 
 	 * @param _option2Enabled true says to provide an options2 field in SSListItem

--- a/swingset/src/main/java/com/nqadmin/swingset/models/SSListItemFormat.java
+++ b/swingset/src/main/java/com/nqadmin/swingset/models/SSListItemFormat.java
@@ -123,12 +123,13 @@ public class SSListItemFormat extends Format {
 		final Format format;
 
 		/**
-		 * @param type
-		 * @param format
+		 * Type and format for an SSListItem.
+		 * @param _type type
+		 * @param _format format
 		 */
-		protected ElemInfo(JDBCType type, Format format) {
-			this.type = type;
-			this.format = format;
+		protected ElemInfo(JDBCType _type, Format _format) {
+			this.type = _type;
+			this.format = _format;
 		}
 	}
 
@@ -209,7 +210,7 @@ public class SSListItemFormat extends Format {
 
 	/**
 	 * Get the default Format for the specified JDBCType.
-	 * @param _jdbcType
+	 * @param _jdbcType format for this
 	 * @return format or null if no format has been set
 	 */
 	public Format getFormat(JDBCType _jdbcType) {
@@ -278,9 +279,10 @@ public class SSListItemFormat extends Format {
 	}
 	
 	/**
-	 * @param source
-	 * @param pos
-	 * @return
+	 * This implementation does not create Object from String.
+	 * @param source text
+	 * @param pos pos
+	 * @return the original string
 	 */
 	@Override
 	public Object parseObject(String source, ParsePosition pos) {
@@ -289,11 +291,11 @@ public class SSListItemFormat extends Format {
 	}
 	
 	/**
-	 * Note that pos is ignored. (at least for now)
-	 * @param _listItem
-	 * @param toAppendTo
-	 * @param pos
-	 * @return
+	 * Note that pos is ignored.
+	 * @param _listItem item being formatted
+	 * @param toAppendTo StringBuffer being worked on
+	 * @param pos pos
+	 * @return StringBuffer being worked on
 	 */
 	@Override
 	public StringBuffer format(Object _listItem, StringBuffer toAppendTo, FieldPosition pos) {

--- a/swingset/src/main/java/com/nqadmin/swingset/models/SSListItemFormat.java
+++ b/swingset/src/main/java/com/nqadmin/swingset/models/SSListItemFormat.java
@@ -313,13 +313,25 @@ public class SSListItemFormat extends Format {
 	}
 
 	/**
+	 * This method allows overriding classes to access the list item
+	 * elements directly without going through remodel.
+	 *
+	 * @param _elemIndex index of element
+	 * @param _listItem container holding the element
+	 * @return the element
+	 */
+	protected Object getElem(int _elemIndex, SSListItem _listItem) {
+		return ((ListItem0) _listItem).getElem(_elemIndex);
+	}
+
+	/**
 	 * Format the indicated element, by default use toString().
 	 * @param _sb append string value to this
 	 * @param _elemIndex index of element
 	 * @param _listItem container holding the element
 	 */
-	protected void appendValue(StringBuffer _sb, int _elemIndex, ListItem0 _listItem) {
-		Object elem = _listItem.getElem(_elemIndex);
+	protected void appendValue(StringBuffer _sb, int _elemIndex, SSListItem _listItem) {
+		Object elem = getElem(_elemIndex, _listItem);
 		if (elem == null) {
 			return;
 		}

--- a/swingset/src/test/java/com/nqadmin/swingset/models/SSListItemFormatTest.java
+++ b/swingset/src/test/java/com/nqadmin/swingset/models/SSListItemFormatTest.java
@@ -213,6 +213,8 @@ public class SSListItemFormatTest {
 
 		// Check exceptions in Format are handled.
 		Format exceptionFormat = new Format() {
+			private static final long serialVersionUID = 1L;
+
 			@Override
 			public StringBuffer format(Object obj, StringBuffer toAppendTo, FieldPosition pos) {
 				throw new UnsupportedOperationException("Not supported yet.");


### PR DESCRIPTION
Add `BaseComboBox.[sg]etListItemFormat` to improve display configurability.

This 2nd PR feels better for handling #145 . The externally visible change is the ability to set the list format on the combo rather than having an overriden method . So any given combo can more easily have it's display customized.

Internally, using a `SSListItemFormatDelegate` enables the improved configurability.

I was guessing that the display of mapping for null option was more for debug and/or identifying issues. Might want to change the default display.
