### PR TITLE
Use environment variable, JAVA_PREFERRED_SCREEN, to place Windows.

### DIFF
--- a/swingset-demo/README.md
+++ b/swingset-demo/README.md
@@ -79,6 +79,9 @@ The swingset-demo uses an in-memory H2 database by default, but can be run using
 
 See "USING ALTERNATE DATABASE SERVERS" at the end of this document for more information.
 
+Note that the default screen for placement of the demo can be specified using the environment variable: `JAVA_PREFERRED_SCREEN`.
+For example, in a dual monitor Linux environment, you can type `export JAVA_PREFERRED_SCREEN=1` prior to running the demo, and the SwingSet demo will appear on the right screen (presuming the left monitor is the default). 
+If the environment variable is not present or out of bound, the default is used.
 
 ## COMPILATION
 

--- a/swingset-demo/pom.xml
+++ b/swingset-demo/pom.xml
@@ -28,6 +28,7 @@
 		<version.log4j>2.19.0</version.log4j>
 		<version.h2>2.1.214</version.h2>
 		<version.java-getopt>1.0.13</version.java-getopt>
+		<version.raelity-lib>1.2.0</version.raelity-lib>
 
 		<!-- PLUGINS -->
 		<!-- Shared by swingset-parent, swingset, and swingset-demo -->
@@ -108,6 +109,14 @@
 			<artifactId>java-getopt</artifactId>
 			<version>${version.java-getopt}</version>
 		</dependency>
+
+		<!-- https://mvnrepository.com/artifact/com.raelity/raelity-lib -->
+		<dependency>
+			<groupId>com.raelity</groupId>
+			<artifactId>raelity-lib</artifactId>
+			<version>${version.raelity-lib}</version>
+		</dependency>
+
 	</dependencies>
 
 	<build>

--- a/swingset-demo/src/main/java/com/nqadmin/swingset/demo/DemoUtil.java
+++ b/swingset-demo/src/main/java/com/nqadmin/swingset/demo/DemoUtil.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Properties;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import com.raelity.lib.ui.Screens;
 
  
 /**
@@ -68,6 +69,7 @@ public class DemoUtil
 //			break;
 //		}
 		
+		Screens.translateToPrefScreen(result);
 		return result;
 	}
 

--- a/swingset-demo/src/main/java/com/nqadmin/swingset/demo/MainClass.java
+++ b/swingset-demo/src/main/java/com/nqadmin/swingset/demo/MainClass.java
@@ -71,6 +71,7 @@ import org.h2.tools.RunScript;
 
 import com.nqadmin.swingset.models.SSCollectionModel;
 import com.nqadmin.swingset.models.SSMysqlSetModel;
+import com.raelity.lib.ui.Screens;
 
 import gnu.getopt.Getopt;
 
@@ -231,6 +232,7 @@ public class MainClass extends JFrame {
 	/**
 	 * Constructor for MainClass
 	 */
+	@SuppressWarnings("LeakingThisInConstructor")
 	public MainClass() {
 
 		// SETUP WINDOW
@@ -302,6 +304,7 @@ public class MainClass extends JFrame {
 		// DISPLAY SCREEN
 		setVisible(true);
 		pack();
+		Screens.translateToPrefScreen(this);
 	}
 
 	/**


### PR DESCRIPTION
No effect if env variable is not present. Could enhance Screens to also consider a property.

It's not hard to manually do this when working with SwingSet demos, but that easily leads to errors when pushing. This PR is not all that urgent, it is something I use a lot.

raelity-lib is pretty small, take a look at the source. You may find ValueMap of interest, extracts/maintains a map key extracted from the value.