### PR TITLE
Add sorting to DataGrid; handle duplicate combo and other fixes

### DIFF
--- a/.hgignore
+++ b/.hgignore
@@ -1,0 +1,10 @@
+/target/
+\.log$
+
+syntax: glob
+*~
+*.sw[pmno]
+*.orig
+*.orig.*
+*.rej
+

--- a/swingset-demo/nb-configuration.xml
+++ b/swingset-demo/nb-configuration.xml
@@ -24,5 +24,6 @@ Any value defined here will override the pom.xml file value but is only applicab
         <org-netbeans-modules-editor-indent.CodeStyle.project.text-limit-width>80</org-netbeans-modules-editor-indent.CodeStyle.project.text-limit-width>
         <org-netbeans-modules-editor-indent.CodeStyle.project.expand-tabs>false</org-netbeans-modules-editor-indent.CodeStyle.project.expand-tabs>
         <org-netbeans-modules-editor-indent.CodeStyle.usedProfile>project</org-netbeans-modules-editor-indent.CodeStyle.usedProfile>
+        <netbeans.hint.jdkPlatform>JDK_1.8</netbeans.hint.jdkPlatform>
     </properties>
 </project-shared-configuration>

--- a/swingset-demo/src/main/java/com/nqadmin/swingset/demo/DataGridExampleSupport.java
+++ b/swingset-demo/src/main/java/com/nqadmin/swingset/demo/DataGridExampleSupport.java
@@ -217,18 +217,20 @@ class DataGridExampleSupport {
 			setAllowDelete((AbstractButton) e.getSource());
 		});
 
-		// trigger for random debug stuff
-		button = new JButton("trigger");
-		buttons.add(button);
-		button.addActionListener((ActionEvent e) -> {
-			System.err.println("BANG");
-			List<Integer> cols = new ArrayList<>();
-			for(int col : dataGrid.getSelectedColumns())
-				cols.add(col);
-
-			System.err.println("selCols: " + cols);
-			//outputColInfo();
-		});
+		if(Boolean.FALSE) {
+			// trigger for random debug stuff
+			button = new JButton("trigger");
+			buttons.add(button);
+			button.addActionListener((ActionEvent e) -> {
+				System.err.println("BANG");
+				List<Integer> cols = new ArrayList<>();
+				for(int col : dataGrid.getSelectedColumns())
+					cols.add(col);
+				
+				System.err.println("selCols: " + cols);
+				//outputColInfo();
+			});
+		}
 
 		// delete selected row
 		button = new JButton("delete");

--- a/swingset-demo/src/main/java/com/nqadmin/swingset/demo/DataGridExampleSupport.java
+++ b/swingset-demo/src/main/java/com/nqadmin/swingset/demo/DataGridExampleSupport.java
@@ -90,33 +90,34 @@ class DataGridExampleSupport {
 	private final SSDataGrid dataGrid;
 	private final Logger logger;
 
-	@SuppressWarnings("ResultOfObjectAllocationIgnored")
 	static void setup(Logger logger, Container uiContainer,
 			RowSet rowset, SSDataGrid dataGrid,
-			int primaryColumn, SSDataValue dataValue,
-			String[] columnNames, Object[] defaultValues)
+			int primaryColumn, SSDataValue dataValue, String[] columnNames, Object[] defaultValues)
 			throws SQLException {
-		new DataGridExampleSupport(logger, uiContainer, rowset, dataGrid,
-				primaryColumn, dataValue, columnNames, defaultValues);
+		DataGridExampleSupport dges = new DataGridExampleSupport(
+				logger, uiContainer, rowset, dataGrid);
+		dges.init(primaryColumn, dataValue, columnNames, defaultValues);
 	}
 
 
-	DataGridExampleSupport(Logger logger, Container uiContainer,
-			RowSet rowset, SSDataGrid dataGrid,
-			int primaryColumn, SSDataValue dataValue,
-			String[] columnNames, Object[] defaultValues)
+	private DataGridExampleSupport(Logger _logger, Container _uiContainer,
+			RowSet _rowset, SSDataGrid _dataGrid)
 			throws SQLException {
 
-		if(!(uiContainer.getLayout() instanceof BorderLayout)) {
+		if(!(_uiContainer.getLayout() instanceof BorderLayout)) {
 			throw new IllegalArgumentException("uiContainer without BorderLayout");
 		}
 
-		this.uiContainer = uiContainer;
-		this.rowset = rowset;
-		this.dataGrid = dataGrid;
-		this.logger = logger;
+		this.uiContainer = _uiContainer;
+		this.rowset = _rowset;
+		this.dataGrid = _dataGrid;
+		this.logger = _logger;
 
-		
+	}
+	
+	private void init(int primaryColumn, SSDataValue dataValue,
+			String[] columnNames, Object[] defaultValues)
+			throws SQLException {
 		// stuff needed if there's going to be an insertion
 		dataGrid.setSSDataGridHandler(new DataGridHandler());
 		dataGrid.setPrimaryColumn(primaryColumn);

--- a/swingset/nb-configuration.xml
+++ b/swingset/nb-configuration.xml
@@ -71,5 +71,6 @@ Any value defined here will override the pom.xml file value but is only applicab
         <org-netbeans-spi-editor-hints-projects.text.x-java.Javac_5f_DIVISION_5f_BY_5f_ZERO.enabled>true</org-netbeans-spi-editor-hints-projects.text.x-java.Javac_5f_DIVISION_5f_BY_5f_ZERO.enabled>
         <netbeans.hint.licensePath>${project.basedir}/LICENSE.ftl</netbeans.hint.licensePath>
         <org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.separateStaticImports>true</org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.separateStaticImports>
+        <netbeans.hint.jdkPlatform>JDK_1.8</netbeans.hint.jdkPlatform>
     </properties>
 </project-shared-configuration>

--- a/swingset/src/main/java/com/nqadmin/swingset/SSDBComboBox.java
+++ b/swingset/src/main/java/com/nqadmin/swingset/SSDBComboBox.java
@@ -190,6 +190,8 @@ public class SSDBComboBox extends SSBaseComboBox<Long, Object, Object>
 		/** Exception if invoked. */
 		public Model() { Objects.requireNonNull(null); } 
 	}
+	// avoid warning for Model() constructor unused
+	static { if(Boolean.FALSE) Objects.isNull(new Model()); }
 
 	/**
 	 * {@inheritDoc }

--- a/swingset/src/main/java/com/nqadmin/swingset/SSDataGrid.java
+++ b/swingset/src/main/java/com/nqadmin/swingset/SSDataGrid.java
@@ -745,54 +745,29 @@ public class SSDataGrid extends JTable {
 
 	/**
 	 * Variable to indicate if rows can be deleted.
-	 * 
-	 * @deprecated use isAllowDeletion()
 	 */
-	protected boolean allowDeletion = true;
+	private boolean allowDeletion = true;
 
 	/**
 	 * Variable to indicate if execute() should be called on the RowSet.
-	 * @deprecated use getCallExecute()
 	 */
-	protected boolean callExecute = true;
-
-	/**
-	 * Number of columns in the RowSet.
-	 * @deprecated use getColumnCount() or getModel.getColumnCount() as appropriate
-	 */
-	protected int columnCount = -1;
+	private boolean callExecute = true;
 
 	/**
 	 * Minimum width of the columns in the data grid.
-	 * @deprecated use getColumnWidth()
 	 */
-	protected int columnWidth = 100;
+	private int columnWidth = 100;
 
 	/**
-	 * DagaGridHandler to help with row deletions, and insertions
-	 * @deprecated always null, no replacement
+	 * Column numbers that have to be hidden.
 	 */
-	protected SSDataGridHandler dataGridHandler;
-
-	/**
-	 * Array used to store the column names that have to hidden.
-	 * @deprecated not used, always null
-	 */
-	protected String[] hiddenColumnNames = null;
-
-	/**
-	 * Array used to store the column numbers that have to be hidden.
-	 * @deprecated always null, use getHiddenColumns()
-	 */
-	protected int[] hiddenColumns = null;
 	private transient List<Integer> hiddenColumnsList = Collections.emptyList();
 
 	/**
 	 * Variable to indicate if the data grid will display an additional row for
 	 * inserting new rows.
-	 * @deprecated use getInsertion()
 	 */
-	protected boolean insertion = true;
+	private boolean insertion = true;
 
 	/**
 	 * Variable indicating that sorting, by clicking on column header,
@@ -809,37 +784,27 @@ public class SSDataGrid extends JTable {
 
 	/**
 	 * Component where messages should be popped up.
-	 * @deprecated use getMessageWindow()
 	 */
-	protected Component messageWindow = null;
-
-	/**
-	 * Number of records retrieved from the RowSet.
-	 * @deprecated use getRowCount()
-	 */
-	protected int rowCount = -1;
+	private Component messageWindow = null;
 
 	/**
 	 * Scrollpane used to scroll datagrid.
-	 * @deprecated use getComponent()
 	 */
-	protected JScrollPane scrollPane = null; // new JScrollPane(JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED,JScrollPane.HORIZONTAL_SCROLLBAR_AS_NEEDED);
+	private JScrollPane scrollPane = null;
 
 	/**
 	 * RowSet from which component will get/set values.
-	 * @deprecated use getRowSet()
 	 */
-	protected RowSet rowSet = null;
+	transient private RowSet rowSet = null;
 
 	/**
 	 * Table model to construct the JTable
-	 * @deprecated use getModel()
 	 */
 	// TODO: why does this variable exist? Use getModel()?
 	// Currently doesn't work to pass model in constructor.
 	// At least get rid of protected.
 	// Looks like it might be used before it becomes the model in use
-	protected SSTableModel tableModel = new SSTableModel();
+	private SSTableModel tableModel = new SSTableModel();
 	private boolean tableModelSet;
 
 	/**
@@ -1015,12 +980,6 @@ public class SSDataGrid extends JTable {
 
 			// SET THE TABLE MODEL FOR JTABLE
 			setModel(tableModel);
-
-			// GET THE ROW COUNT
-			rowCount = tableModel.getRowCount();
-
-			// GET THE COLUMN COUNT
-			columnCount = tableModel.getColumnCount();
 
 		} catch (final SQLException se) {
 			logger.error("SQL Exception.", se);
@@ -1280,7 +1239,6 @@ public class SSDataGrid extends JTable {
 		// SPECIFY THE MESSAGE WINDOW TO WHICH THE TABLE MODEL HAS TO POP UP
 		// ERROR MESSAGES.
 		tableModel.setMessageWindow(messageWindow);
-		tableModel.setJTable(this);
 
 		// THIS CAUSES THE JTABLE TO DISPLAY THE HORIZONTAL SCROLL BAR AS NEEDED.
 		// CODE IN HIDECOLUMNS FUNCTION DEPENDS ON THIS VARIABLE.
@@ -1489,6 +1447,7 @@ public class SSDataGrid extends JTable {
 	 * @param _values        the values for the column numbers specified in
 	 *                       _columnNumbers.
 	 */
+	// TODO: Use List not Array
 	public void setDefaultValues(final int[] _columnNumbers, final Object[] _values) {
 
 		tableModel.setDefaultValues(_columnNumbers, _values);
@@ -1511,6 +1470,7 @@ public class SSDataGrid extends JTable {
 	 * @throws SQLException if the specified column name is not present in the
 	 *                      RowSet
 	 */
+	// TODO: Use List not Array
 	public void setDefaultValues(final String[] _columnNames, final Object[] _values) throws SQLException {
 
 		int[] columnNumbers = null;
@@ -1536,6 +1496,7 @@ public class SSDataGrid extends JTable {
 	 * @param _headers array of string objects representing the header of each
 	 *                 column.
 	 */
+	// TODO: Use List not Array
 	public void setHeaders(final String[] _headers) {
 		tableModel.setHeaders(_headers);
 	}
@@ -1574,12 +1535,11 @@ public class SSDataGrid extends JTable {
 	}
 
 	/**
-	 * Sets the column numbers that should be hidden. The SSDataGrid sets the column
+	 * Sets the columns, by name, that should be hidden. The SSDataGrid sets the column
 	 * width of these columns to 0. The columns are set to zero width rather than
-	 * removing the column from the table. Thus preserving the column numbering.If a
+	 * removing the column from the table. Thus preserving the column numbering. If a
 	 * column is removed then the column numbers for columns after the removed
-	 * column will change. Even if the column is specified as hidden user will be
-	 * seeing a tiny strip. Make sure that you specify the hidden column numbers in
+	 * column will change. Make sure that you specify the hidden column numbers in
 	 * the uneditable column list.
 	 * <p>
 	 * Currently not a bean property since there is no associated variable.
@@ -1735,6 +1695,7 @@ public class SSDataGrid extends JTable {
 	 * deletions and insertions
 	 *
 	 * @param _dataGridHandler implementation of SSDataGridHandler interface.
+	 * @deprecated Use SSTableModel.setSSDataGridHandler
 	 */
 	public void setSSDataGridHandler(final SSDataGridHandler _dataGridHandler) {
 		tableModel.setSSDataGridHandler(_dataGridHandler);
@@ -1762,6 +1723,7 @@ public class SSDataGrid extends JTable {
 	 * @param _columnNumbers array specifying the column numbers which should be
 	 *                       uneditable.
 	 */
+	// TODO: Use List not Array
 	public void setUneditableColumns(final int[] _columnNumbers) {
 		tableModel.setUneditableColumns(_columnNumbers);
 	}
@@ -1777,6 +1739,7 @@ public class SSDataGrid extends JTable {
 	 *                     uneditable.
 	 * @throws SQLException	SQLException
 	 */
+	// TODO: Use List not Array
 	public void setUneditableColumns(final String[] _columnNames) throws SQLException {
 		int[] columnNumbers = null;
 		if (_columnNames != null) {

--- a/swingset/src/main/java/com/nqadmin/swingset/SSTableModel.java
+++ b/swingset/src/main/java/com/nqadmin/swingset/SSTableModel.java
@@ -126,9 +126,8 @@ public class SSTableModel extends AbstractTableModel {
 	/**
 	 * Implementation of SSCellEditing interface used to determine dynamically if a
 	 * given cell can be edited and to determine if a given value is valid.
-	 * @deprecated use the 
 	 */
-	protected SSCellEditing cellEditing = null;
+	private SSCellEditing cellEditing = null;
 
 	/**
 	 * Number of columns in the RowSet.
@@ -137,48 +136,36 @@ public class SSTableModel extends AbstractTableModel {
 
 	/**
 	 * Window where messages should be displayed.
-	 * @deprecated direct r/w access not needed
 	 */
-	protected transient Component component = null;
+	private transient Component component = null;
 
 	/**
 	 * Implementation of DataGridHandler interface used to determine dynamically if
 	 * a given row can be deleted, and what to do before and after a row is added or
 	 * removed.
-	 * @deprecated r/w not needed, go through table
 	 */
-	protected SSDataGridHandler dataGridHandler = null;
+	transient private SSDataGridHandler dataGridHandler = null;
 
 	/**
 	 * Implementation of SSDataValue interface used to determine PK value for new
 	 * rows.
-	 * @deprecated direct r/w access not needed
 	 */
-	protected SSDataValue dataValue = null;
+	transient private SSDataValue dataValue = null;
 
 	/**
 	 * Map to store the default values of different columns.
-	 * @deprecated direct r/w access not needed
 	 */
-	protected HashMap<Integer, Object> defaultValuesMap = null;
+	private HashMap<Integer, Object> defaultValuesMap = null;
 
 	/**
 	 * JTable headers.
-	 * @deprecated direct r/w access not needed
 	 */
-	protected transient String[] headers = null;
-
-	/**
-	 * List of hidden columns.
-	 * @deprecated no replacement, this is view oriented
-	 */
-	protected int[] hiddenColumns = null;
+	private transient String[] headers = null;
 
 	/**
 	 * Indicator to determine if the RowSet is on the insertion row.
-	 * @deprecated direct r/w access not needed
 	 */
-	protected boolean inInsertRow = false;
+	private boolean inInsertRow = false;
 
 	/**
 	 * Column containing primary key.
@@ -187,27 +174,16 @@ public class SSTableModel extends AbstractTableModel {
 
 	/**
 	 * Number of rows in the RowSet.
-	 * @deprecated direct r/w access not needed
 	 */
-	protected transient int rowCount = 0;
+	// TODO: Can the result set change and invalidate this?
+	private transient int rowCount = 0;
 
-	/**
-	 * @deprecated direct r/w access not needed
-	 */
-	protected RowSet rowset = null;
-
-	/**
-	 * JTable being modeled.
-	 * @deprecated no not use
-	 */
-	// TODO: remove this
-	protected transient JTable table = null;
+	transient private RowSet rowset = null;
 
 	/**
 	 * List of uneditable columns.
-	 * @deprecated direct r/w access not needed
 	 */
-	protected int[] uneditableColumns = null;
+	private int[] uneditableColumns = null;
 
 	/**
 	 * Constructs a SSTableModel object. If this contructor is used the
@@ -473,7 +449,7 @@ public class SSTableModel extends AbstractTableModel {
 	 * Initializes the SSTableModel. (Gets the column count and row count for the
 	 * given RowSet.)
 	 */
-	protected void init() {
+	private void init() {
 		try {
 
 			//columnCount = rowset.getColumnCount();
@@ -743,23 +719,6 @@ public class SSTableModel extends AbstractTableModel {
 	}
 
 	/**
-	 * Sets the column numbers that should be hidden. The SSDataGrid sets the column
-	 * width of these columns to 0. The columns are set to zero width rather than
-	 * removing the column from the table. Thus preserving the column numbering. If
-	 * a column is removed then the column numbers for columns after the removed
-	 * column will change. Even if the column is specified as hidden user will be
-	 * seeing a tiny strip. Make sure that you specify the hidden column numbers in
-	 * the uneditable column list.
-	 *
-	 * @param _columnNumbers array specifying the column numbers which should be
-	 *                       hidden.
-	 * @deprecated no replacement, hidden columns are view oriented
-	 */
-	public void setHiddenColumns(final int[] _columnNumbers) {
-		hiddenColumns = _columnNumbers;
-	}
-
-	/**
 	 * Sets row insertion indicator.
 	 *
 	 * @param _insert true if user can insert new rows, else false.
@@ -775,18 +734,6 @@ public class SSTableModel extends AbstractTableModel {
 			else
 				fireTableRowsDeleted(rowCount, rowCount);
 		}
-	}
-
-	/**
-	 * This sets the JTable to which the table model is bound to. When an insert row
-	 * has taken place TableModel tries to update the UI.
-	 *
-	 * @param _table JTable to which SSTableModel is bound to.
-	 * @deprecated no replacement
-	 */
-	@Deprecated
-	public void setJTable(final JTable _table) {
-		//table = _table;
 	}
 
 	/**

--- a/swingset/src/main/java/com/nqadmin/swingset/models/AbstractComboBoxListSwingModel.java
+++ b/swingset/src/main/java/com/nqadmin/swingset/models/AbstractComboBoxListSwingModel.java
@@ -55,6 +55,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.WeakHashMap;
 
+import javax.swing.ComboBoxModel;
 import javax.swing.DefaultComboBoxModel;
 import javax.swing.DefaultListCellRenderer;
 import javax.swing.JComboBox;
@@ -62,6 +63,7 @@ import javax.swing.JComponent;
 import javax.swing.JList;
 import javax.swing.ListCellRenderer;
 import javax.swing.ListModel;
+import javax.swing.MutableComboBoxModel;
 import javax.swing.event.ListDataEvent;
 import javax.swing.event.ListDataListener;
 import javax.swing.plaf.basic.BasicComboBoxRenderer;
@@ -323,6 +325,40 @@ public abstract class AbstractComboBoxListSwingModel {
 	//
 	// TODO: uninstall
 	//
+
+	/**
+	 * Special case usage, grab the model configured for a JComboBox.
+	 * @param <T> model elements
+	 * @param _model the model source
+	 * @return the model
+	 */
+	protected static <T>MutableComboBoxModel<T> getSimpleComboBoxModel(AbstractComboBoxListSwingModel _model) {
+		if(_model.installed) {
+			throw new IllegalStateException("model already installed");
+		}
+		_model.installed = true;
+		_model.comboBoxModel = true;
+		@SuppressWarnings("unchecked")
+		MutableComboBoxModel<T> m = (MutableComboBoxModel<T>) _model.modelProxy;
+		return m;
+	}
+
+	/**
+	 * Special case usage, grab the model configured for a JList.
+	 * @param <T> model elements
+	 * @param _model the model source
+	 * @return the model
+	 */
+	protected static <T>ListModel<T> getSimpleListModel(AbstractComboBoxListSwingModel _model) {
+		if(_model.installed) {
+			throw new IllegalStateException("model already installed");
+		}
+		_model.installed = true;
+		_model.comboBoxModel = false;
+		@SuppressWarnings("unchecked")
+		ListModel<T> m = (ListModel<T>) _model.modelProxy;
+		return m;
+	}
 
 	/**
 	 * Installs a ListCellRenderer into the JComponent which

--- a/swingset/src/main/java/com/nqadmin/swingset/models/SimpleComboListSwingModels.java
+++ b/swingset/src/main/java/com/nqadmin/swingset/models/SimpleComboListSwingModels.java
@@ -1,0 +1,134 @@
+/* *****************************************************************************
+ * Copyright (C) 2023, Prasanth R. Pasala, Brian E. Pangburn, & The Pangburn Group
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Contributors:
+ *   Prasanth R. Pasala
+ *   Brian E. Pangburn
+ *   Diego Gil
+ *   Man "Bee" Vo
+ *   Ernie R. Rael
+ * ****************************************************************************/
+
+package com.nqadmin.swingset.models;
+
+import java.util.List;
+
+import javax.swing.ComboBoxModel;
+import javax.swing.ListModel;
+
+/** Simple JList JComboBox models that handle SSLIstItem 
+ * without locking or listItemFormat.
+ * <p>
+ * Example usage as an inner
+ * class where all the combo data is accessed from an outer class
+ * by the index in the comboList.
+ * <pre>
+ * {@code 
+ * // outer class does
+ * 	ComboBoxModel<MyComboModels.MyComboItem> model
+ * 		= new MyComboModels().getComboModel()
+ * 
+ * private final class MyComboModels extends SimpleComboListSwingModels {
+ * 	
+ * 	private MyComboModels() {
+ * 		super(2, new ArrayList<>(items.length));
+ * 		// initialization
+ * 		for (int i = 0; i < items.length; i++) {
+ * 			getRemodel().add(new MyComboItem(i));
+ * 		}
+ * 	}
+ * 
+ * 	@SuppressWarnings("unchecked")
+ * 	@Override
+ * 	public ComboBoxModel<MyComboItem> getComboModel() {
+ * 		return (ComboBoxModel<MyComboItem>) super.getComboModel();
+ * 	}
+ * 
+ * 	class MyComboItem implements ListItem0, Cloneable {
+ * 		private final int listIdx;
+ * 
+ * 		public MyComboItem(int _listIdx) { listIdx = _listIdx; }
+ * 		// ...
+ * 	}
+ * }
+ * }
+ * </pre>
+ * {@inheritDoc} */
+public abstract class SimpleComboListSwingModels extends AbstractComboBoxListSwingModel
+{
+
+	/**
+	 * Bounce to super. Typical usage:
+	 * @param _itemNumElems see super
+	 * @param _itemList  see super
+	 */
+	public SimpleComboListSwingModels(int _itemNumElems, List<SSListItem> _itemList) {
+		super(_itemNumElems, _itemList);
+	}
+
+	/** {@inheritDoc}
+	 */
+	protected ListModel<?> getListModel() {
+		return AbstractComboBoxListSwingModel.getSimpleListModel(this);
+	}
+
+	/** {@inheritDoc}
+	 */
+	protected ComboBoxModel<?> getComboModel() {
+		return AbstractComboBoxListSwingModel.getSimpleComboBoxModel(this);
+	}
+
+	/** {@inheritDoc} */
+	@Override
+	protected void checkState() {
+	}
+
+	/** {@inheritDoc} */
+	@Override
+	protected void remodelTakeWriteLock() {
+	}
+
+	/** {@inheritDoc} */
+	@Override
+	protected void remodelReleaseWriteLock(AbstractComboBoxListSwingModel.Remodel remodel) {
+	}
+
+	/** {@inheritDoc} */
+	final public class Remodel extends AbstractComboBoxListSwingModel.Remodel { }
+	private final Remodel remodel = new Remodel();
+
+	/** {@inheritDoc} */
+	@Override
+	public final Remodel getRemodel() {
+		// default is no locking, re-use the model.
+		return remodel;
+	}
+    
+}


### PR DESCRIPTION
Three commits
- #7 Swing's column sorting added to `DataGrid`; interactions with insert row.
- #126 Use `SimpleComboModel` so duplicate names in combo selector are unique.
- When clicking on column, cycle through unsorted. Fix `hideColumns()`. Simplify `getSelectedColumns()`.

Try this stuff using Example5.

This PR fixes primary issues. It does not handle the 4.x specific stuff like #12 and #8. Or new features like filtering #127, or #6 or #9. But note that Swing's sorting includes filtering capability, need an SS API.

### open questions to consider during review
- What kind of handling is required by Grid's ComboBox for null and/or unknown values coming from the database? I think `getCellEditorValue()` does the same thing, but I think the old behavior was inconsistent when `getSelectedIndex()` was -1.
- Throw if `SSDataGrid.setModel()` and currently has a `SSTableModel`?
- Note change to Control-X handling (my use of Ctrl-X was broken).
- Don't give `SSTableModel` a JTable.
- Why is there `SSDataGrid.tableModel`?
- There's arrays in API, convert them to List<>.
- What is the `messageWindow` all about?
- The hidden columns array shows up in both table and model.
- Why rowCount/columnCount variables in both grid/model?
- There's a bunch of TODOs added, comments appreciated.
