### PR TITLE
Fix error recovery after errors during `SSTextField` edit

### DIFF
--- a/.hgignore
+++ b/.hgignore
@@ -1,0 +1,12 @@
+/target/
+\.log$
+
+syntax: glob
+*~
+*.sw[pmno]
+*.orig
+*.orig.*
+*.rej
+
+syntax: rootglob
+NOTES-LOCAL

--- a/swingset-demo/src/main/resources/suppliers_and_parts.sql
+++ b/swingset-demo/src/main/resources/suppliers_and_parts.sql
@@ -54,7 +54,7 @@ CREATE TABLE IF NOT EXISTS supplier_data
 ( 
     supplier_id INTEGER DEFAULT nextval('supplier_data_seq') NOT NULL PRIMARY KEY,
     supplier_name VARCHAR(50), 
-    status SMALLINT, 
+    status SMALLINT NOT NULL CHECK (status <= 999), 
     city VARCHAR(50)
 );
 

--- a/swingset/src/main/java/com/nqadmin/swingset/SSTextField.java
+++ b/swingset/src/main/java/com/nqadmin/swingset/SSTextField.java
@@ -300,7 +300,7 @@ public class SSTextField extends JTextField implements SSComponentInterface {
 			 DEFAULT_MASK, DEFAULT_NUMBER_OF_DECIMAL_PLACES, ANY_ALIGNMENT);
 	}
 
-	/** All the contructors feed through here */
+	/** All the constructors feed through here */
 	private SSTextField(String _text, final RowSet _rowSet, final String _boundColumnName,
 	final int _mask, final int _numberOfDecimalPlaces, final int _align) {
 		super(_text);
@@ -319,7 +319,12 @@ public class SSTextField extends JTextField implements SSComponentInterface {
 	/** Only non-null during object construction. */
 	transient private SSCommon constructingSSCommon;
 
-	/** For capturing text before modification */
+	/**
+	 * The following is called during JTextField's constructor and the ssCommon
+	 * is needed to create the document model. So we use constructingSSCommon()
+	 * to stash ssCommon in the constructingSSCommon variable, then during
+	 * SSTextField's constructor we save it in its final location.
+	 */
 	@Override
 	protected Document createDefaultModel() {
 		return constructingSSCommon().new SSPlainDocument();

--- a/swingset/src/main/java/com/nqadmin/swingset/utils/SSCommon.java
+++ b/swingset/src/main/java/com/nqadmin/swingset/utils/SSCommon.java
@@ -171,6 +171,11 @@ public class SSCommon {
 						ok = setBoundColumnText(((JTextComponent) getSSComponent()).getText());
 					} finally {
 						if (!ok) {
+							// TODO:
+							// How about moving a state tracking variable to
+							// add/removeSSDocumentListener()?
+							// addSSDocumentListener() then uses listenerNeedsRestoration.
+
 							// restore previous text value
 							if(previousValue != null) {
 								if (ssComponentListenerAdded) {


### PR DESCRIPTION
Fix #175
Return boolean from `updateColumnText` indicating if an error occurred.
Add `DocumentFilter` to capture text field value before edit.
Use `SSSQLNullException` instead of `NPE`.
Deprecate methods that change `SSCommon` or `ssComponent`.
Add some constraints for `supplier_data` table to make it easier to test error recovery.
