### PR TITLE
Make grid database type usage consistent with RowSetOps

### DIFF
--- a/swingset-demo/src/main/java/com/nqadmin/swingset/demo/Example3.java
+++ b/swingset-demo/src/main/java/com/nqadmin/swingset/demo/Example3.java
@@ -84,6 +84,7 @@ public class Example3 extends JFrame {
 	JLabel lblSupplierName = new JLabel("Supplier");
 	JLabel lblPartName = new JLabel("Part");
 	JLabel lblQuantity = new JLabel("Quantity");
+	JLabel lblShipDate = new JLabel("Ship Date");
 	
 	/**
 	 * bound component declarations
@@ -92,6 +93,7 @@ public class Example3 extends JFrame {
 	SSDBComboBox cmbSupplierName = null;
 	SSDBComboBox cmbPartName = null;
 	SSTextField txtQuantity = new SSTextField();
+	SSTextField txtShipDate = new SSTextField();
 	
 	/**
 	 * database component declarations
@@ -214,6 +216,7 @@ public class Example3 extends JFrame {
 			cmbPartName.setAllowNull(false);
 			cmbPartName.bind(rowset, "part_id");
 			txtQuantity.bind(rowset, "quantity");
+			txtShipDate.bind(rowset, "ship_date");
 
 		// RUN DB COMBO QUERIES
 			try {
@@ -231,12 +234,14 @@ public class Example3 extends JFrame {
 			lblSupplierName.setPreferredSize(MainClass.labelDim);
 			lblPartName.setPreferredSize(MainClass.labelDim);
 			lblQuantity.setPreferredSize(MainClass.labelDim);
+			lblShipDate.setPreferredSize(MainClass.labelDim);
 
 		// SET BOUND COMPONENT DIMENSIONS
 			txtSupplierPartID.setPreferredSize(MainClass.ssDim);
 			cmbSupplierName.setPreferredSize(MainClass.ssDim);
 			cmbPartName.setPreferredSize(MainClass.ssDim);
 			txtQuantity.setPreferredSize(MainClass.ssDim);
+			txtShipDate.setPreferredSize(MainClass.ssDim);
 
 		// SETUP THE CONTAINER AND LAYOUT THE COMPONENTS
 			final Container contentPane = getContentPane();
@@ -252,6 +257,8 @@ public class Example3 extends JFrame {
 			contentPane.add(lblPartName, constraints);
 			constraints.gridy = 3;
 			contentPane.add(lblQuantity, constraints);
+			constraints.gridy = 4;
+			contentPane.add(lblShipDate, constraints);
 
 			constraints.gridx = 1;
 			constraints.gridy = 0;
@@ -262,9 +269,11 @@ public class Example3 extends JFrame {
 			contentPane.add(cmbPartName, constraints);
 			constraints.gridy = 3;
 			contentPane.add(txtQuantity, constraints);
+			constraints.gridy = 4;
+			contentPane.add(txtShipDate, constraints);
 
 			constraints.gridx = 0;
-			constraints.gridy = 4;
+			constraints.gridy = 5;
 			constraints.gridwidth = 2;
 			contentPane.add(navigator, constraints);
 

--- a/swingset/src/main/java/com/nqadmin/swingset/SSTableModel.java
+++ b/swingset/src/main/java/com/nqadmin/swingset/SSTableModel.java
@@ -607,8 +607,7 @@ public class SSTableModel extends AbstractTableModel {
 				
 				// COLUMNS SPECIFIED START FROM 0 BUT FOR SSROWSET THEY START FROM 1
 				//final int type = rowset.getColumnType(column.intValue() + 1);
-				updateColumnObject(rowset, defaultValuesMap.get(column), column + 1,
-								   RowSetOps.getJDBCColumnType(rowset, column + 1));
+				updateColumnObject(rowset, defaultValuesMap.get(column), column + 1);
 
 			} // END OF WHILE
 
@@ -692,8 +691,7 @@ public class SSTableModel extends AbstractTableModel {
 	protected void setPrimaryColumn() {
 		try {
 			//final int type = rowset.getColumnType(primaryColumn + 1);
-			updateColumnObject(rowset, dataValue.getPrimaryColumnValue(), primaryColumn + 1,
-							   RowSetOps.getJDBCColumnType(rowset, primaryColumn + 1));
+			updateColumnObject(rowset, dataValue.getPrimaryColumnValue(), primaryColumn + 1);
 		} catch (final SQLException se) {
 			logger.error("SQL Exception while insering Primary Key value.",  se);
 			if (component != null) {
@@ -784,10 +782,10 @@ public class SSTableModel extends AbstractTableModel {
 		Object valueCopy = _value;
 
 		// GET THE TYPE OF THE COLUMN
-		int type;
+		JDBCType type;
 		try {
 			//type = rowset.getColumnType(_column + 1);
-			type = RowSetOps.getColumnType(rowset, _column + 1);
+			type = RowSetOps.getJDBCColumnType(rowset, _column + 1);
 		} catch (final SQLException se) {
 			logger.error("SQL Exception while updating value.",  se);
 			if (component != null) {
@@ -799,11 +797,11 @@ public class SSTableModel extends AbstractTableModel {
 		// TODO Clean this up. Utilize java.util.Time.
 
 		// IF COPYING VALUES THE DATE WILL COME AS STRING SO CONVERT IT TO DATE OBJECT.
-		if (type == Types.DATE) {
+		if (type == JDBCType.DATE) {
 			if (valueCopy instanceof String) {
 				valueCopy = SSCommon.getSQLDate((String) valueCopy);
 			}
-		} else if (type == Types.TIMESTAMP) {
+		} else if (type == JDBCType.TIMESTAMP) {
 			if (valueCopy instanceof String) {
 				valueCopy = new Timestamp(SSCommon.getSQLDate((String) valueCopy).getTime());
 			}
@@ -849,7 +847,7 @@ public class SSTableModel extends AbstractTableModel {
 				return;
 			}
 			
-			updateColumnObject(rowset, valueCopy, _column + 1, JDBCType.valueOf(type));
+			updateColumnObject(rowset, valueCopy, _column + 1, type);
 
 			rowset.updateRow();
 

--- a/swingset/src/main/java/com/nqadmin/swingset/datasources/RowSetOps.java
+++ b/swingset/src/main/java/com/nqadmin/swingset/datasources/RowSetOps.java
@@ -568,11 +568,15 @@ public class RowSetOps {
 
 // TODO: Probably a better way to handle date to timestamp conversion. Formatter?
 // 2022-05-31_BP: Probably best to cast to a LocalDateTime and return if that fails.
-			Timestamp timestampValue;
+			Timestamp timestampValue = null;
 			try {
-				if (_updatedValue.length() == 19 || _updatedValue.length() > 20) {
-					//System.err.println("TIMESTAMP update: " + _updatedValue);
+				if (_updatedValue.length() == 10) {
+					Date dateValue = SSCommon.getSQLDate(_updatedValue);
+					timestampValue = new Timestamp(dateValue.getTime());
+				} else if (_updatedValue.length() == 19 || _updatedValue.length() > 20) {
 					timestampValue = java.sql.Timestamp.valueOf(_updatedValue);
+				}
+				if (timestampValue != null) {
 					_rowSet.updateTimestamp(_columnName, timestampValue);
 				}
 			} catch(IllegalArgumentException ex) {
@@ -781,6 +785,48 @@ public class RowSetOps {
 	 * @throws SQLException  thrown if a database error is encountered
 	 */
 	public static void updateColumnObject(RowSet _rowSet, Object _value, int _columnIndex, JDBCType type) throws SQLException {
+		if (Boolean.TRUE)
+			updateColumnObject1(_rowSet, _value, _columnIndex);
+		else
+			updateColumnObject2(_rowSet, _value, _columnIndex, type);
+	}
+
+	/**
+	 * Update the Grid's RowSet at the specified column index with the given Object value.
+	 * RowSet. Operate on the current row.
+	 * <p>
+	 * When the user changes/edits the SSDataGrid cell this method propagates the
+	 * change to the RowSet. A separate call is required to flush/commit the change
+	 * to the database.
+	 *
+	 * @param _rowSet RowSet on which to operate
+	 * @param _value string to be type-converted as needed and updated in
+	 *                      underlying RowSet column
+	 * @param _columnIndex   index of the database column
+	 * @throws SQLException  thrown if a database error is encountered
+	 */
+	public static void updateColumnObject(RowSet _rowSet, Object _value, int _columnIndex) throws SQLException {
+		if (Boolean.TRUE)
+			updateColumnObject1(_rowSet, _value, _columnIndex);
+		else
+			updateColumnObject2(_rowSet, _value, _columnIndex, getJDBCColumnType(_rowSet, _columnIndex));
+	}
+
+	/**
+	 * Update the Grid's RowSet at the specified column index with the given Object value.
+	 * RowSet. Operate on the current row.
+	 * <p>
+	 * When the user changes/edits the SSDataGrid cell this method propagates the
+	 * change to the RowSet. A separate call is required to flush/commit the change
+	 * to the database.
+	 *
+	 * @param _rowSet RowSet on which to operate
+	 * @param _value string to be type-converted as needed and updated in
+	 *                      underlying RowSet column
+	 * @param _columnIndex   index of the database column
+	 * @throws SQLException  thrown if a database error is encountered
+	 */
+	public static void updateColumnObject1(RowSet _rowSet, Object _value, int _columnIndex) throws SQLException {
 		_rowSet.updateObject(_columnIndex, _value);
 	}
 

--- a/swingset/src/main/java/com/nqadmin/swingset/utils/SSCommon.java
+++ b/swingset/src/main/java/com/nqadmin/swingset/utils/SSCommon.java
@@ -298,9 +298,11 @@ public class SSCommon implements Serializable {
 	 * @param _strDate date string in "[m]m/[d]d/yyyy" format
 	 *
 	 * @return return SQL date for the string specified
-	 * @throws NoSuchElementException if there are no more tokens in this tokenizer's string
+	 * @throws IllegalArgumentException if data conversion fails
 	 */
-	public static Date getSQLDate(final String _strDate) {
+	// TODO: check that all callers handle excepted as needed
+	public static Date getSQLDate(final String _strDate)
+	throws IllegalArgumentException {
 		if (_strDate == null) {
 			return null;
 		}
@@ -309,10 +311,14 @@ public class SSCommon implements Serializable {
 			return null;
 		}
 		if (strDate.contains("/")) {
-			StringTokenizer strtok = new StringTokenizer(strDate, "/", false);
-			String month = strtok.nextToken();
-			String day = strtok.nextToken();
-			strDate = strtok.nextToken() + "-" + month + "-" + day;
+			try {
+				StringTokenizer strtok = new StringTokenizer(strDate, "/", false);
+				String month = strtok.nextToken();
+				String day = strtok.nextToken();
+				strDate = strtok.nextToken() + "-" + month + "-" + day;
+			} catch (NoSuchElementException ex) {
+				throw new IllegalArgumentException("Date conversion: not enough tokens", ex);
+			}
 		}
 		return Date.valueOf(strDate);
 	}


### PR DESCRIPTION
@prasanthreddy-git @bpangburn 

About using JDBCType Enum

Goals/issues
- Consistent treatment of `JDBCTypes` between grid and `RowSetOps`.
- Handling of java objects, currently `RowSetOps` works only with strings. (I think)
- Follow `JDBC` spec (**noticed some non-compliance in `RowSetOps`**);
  mostly because `FLOAT` is `Double`, `REAL` is `Float`.

In `SSTableModel` there are several places where's there's a TODO comment about
using `JDBCType`. I think those comments were already there from way back,
before this Grid PR. 

This PR changes a simple case:
`getColumnClass` modified using `RowSetOps` methods. `findJavaTypeClass()` handles
more types that Grid was using, and some are handled differently:
- FLOAT returns Double.class
- NUMERIC/DECIMAL return BigDecimal.class
- More time related types handled
- More string types handled
- default is an exception instead of Object.class

Take a look, if it makes sense, other places can be modified to match. I'm
unclear about the type mapping and/or how it interacts with the Grid. An
additional issue, in `SSDataGrid` there working on an object and casting it to a
specific type; that's currently not in `RowSetOps`. In `RowSetOps` it's mostly
working with a string. Maybe working with objects needs to be put into
`RowSetOps`.
