### PR TITLE
Example using 3rd party SimpleValidation framewith with SwingSet

### DIFF
--- a/swingset-demo/pom.xml
+++ b/swingset-demo/pom.xml
@@ -117,6 +117,12 @@
 			<version>${version.raelity-lib}</version>
 		</dependency>
 
+		<!-- https://mvnrepository.com/artifact/com.mastfrog/simplevalidation-standalone -->
+		<dependency>
+			<groupId>com.mastfrog</groupId>
+			<artifactId>simplevalidation-standalone</artifactId>
+			<version>1.14.1</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/swingset-demo/src/main/java/com/nqadmin/swingset/demo/Example1.java
+++ b/swingset-demo/src/main/java/com/nqadmin/swingset/demo/Example1.java
@@ -56,6 +56,13 @@ import com.nqadmin.swingset.SSDBNavImpl;
 import com.nqadmin.swingset.SSDataNavigator;
 import com.nqadmin.swingset.SSTextField;
 import com.nqadmin.swingset.decorators.TextComponentValidator;
+import com.nqadmin.swingset.demo.simpval.SVUtils;
+import com.nqadmin.swingset.demo.simpval.StringValidator;
+import javax.swing.JPanel;
+import org.netbeans.validation.api.ui.ValidationGroup;
+import org.netbeans.validation.api.ui.ValidationItem;
+import org.netbeans.validation.api.ui.swing.SwingValidationGroup;
+import org.netbeans.validation.api.ui.swing.ValidationPanel;
 
 /**
  * This example displays data from the supplier_data table.
@@ -109,6 +116,7 @@ public class Example1 extends JFrame {
 
 		// SET SCREEN TITLE
 			super("Example1");
+			JFrame frame = this;
 
 		// SET CONNECTION
 			connection = _dbConn;
@@ -120,12 +128,23 @@ public class Example1 extends JFrame {
 			setLocation(DemoUtil.getChildScreenLocation(this.getName()));
 		
 		// SET A VALIDATOR (may be a no-op is disabled in SwingSet library)
-			txtSupplierName.getSSCommon().setValidator(new TextComponentValidator() {
-				@Override
-				public boolean validate() {
-					return !jc().getText().equalsIgnoreCase("oops");
-				}
-			});
+			final boolean USE_SIMPLE_VALIDATION = true;
+			//SSTextComponentValidationItem valSupplierName = null;
+			ValidationItem decoSupplierName = null;
+			if (!USE_SIMPLE_VALIDATION) {
+				txtSupplierName.getSSCommon().setValidator(new TextComponentValidator() {
+					@Override
+					public boolean validate() {
+						return !jc().getText().equalsIgnoreCase("oops");
+					}
+				});
+			} else {
+				SwingValidationGroup.setComponentName(txtSupplierName, "Supplier Name");
+				StringValidator validator = SVUtils.getStringValidator(
+						(model) -> !"oops".equalsIgnoreCase(model),
+						() -> "Supplier can not be 'oops'");
+				decoSupplierName = SVUtils.decorator(txtSupplierName, validator);
+			}
 
 		// INITIALIZE DATABASE CONNECTION AND COMPONENTS
 			try {
@@ -226,12 +245,14 @@ public class Example1 extends JFrame {
 			txtSupplierStatus.setPreferredSize(MainClass.ssDim);
 
 		// SETUP THE CONTAINER AND LAYOUT THE COMPONENTS
-			final Container contentPane = getContentPane();
+			final Container contentPane = new JPanel();
 			contentPane.setLayout(new GridBagLayout());
 			final GridBagConstraints constraints = new GridBagConstraints();
 
 			constraints.gridx = 0;
 			constraints.gridy = 0;
+			constraints.weightx = .40;
+			constraints.anchor = GridBagConstraints.WEST;
 			contentPane.add(lblSupplierID, constraints);
 			constraints.gridy = 1;
 			contentPane.add(lblSupplierName, constraints);
@@ -242,6 +263,9 @@ public class Example1 extends JFrame {
 
 			constraints.gridx = 1;
 			constraints.gridy = 0;
+			constraints.weightx = .60;
+			constraints.anchor = GridBagConstraints.CENTER;
+			constraints.fill = GridBagConstraints.HORIZONTAL;
 			contentPane.add(txtSupplierID, constraints);
 			constraints.gridy = 1;
 			contentPane.add(txtSupplierName, constraints);
@@ -258,9 +282,21 @@ public class Example1 extends JFrame {
 		// DISABLE THE PRIMARY KEY
 			txtSupplierID.setEnabled(false);
 
+		// SET UP THE SIMPLE VALIDATION PANEL
+			JPanel uiPanel;
+			if (USE_SIMPLE_VALIDATION) {
+				ValidationPanel valiPanel = new ValidationPanel();
+				valiPanel.setInnerComponent(contentPane);
+				ValidationGroup group = valiPanel.getValidationGroup();
+				group.addItem(decoSupplierName, false);
+				uiPanel =  valiPanel;
+			} else {
+				uiPanel = (JPanel) contentPane;
+			}
 		// MAKE THE JFRAME VISIBLE
-			setVisible(true);
-			pack();
+			frame.add(uiPanel);
+			frame.pack();
+			frame.setVisible(true);
 	}
 
 }

--- a/swingset-demo/src/main/java/com/nqadmin/swingset/demo/simpval/SSTextComponentValidationItem.java
+++ b/swingset-demo/src/main/java/com/nqadmin/swingset/demo/simpval/SSTextComponentValidationItem.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2010-2019 Tim Boudreau
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.nqadmin.swingset.demo.simpval;
+
+import javax.swing.SwingUtilities;
+import org.netbeans.validation.api.ui.*;
+
+/*
+import java.awt.EventQueue;
+import java.awt.event.FocusEvent;
+import java.awt.event.FocusListener;
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+
+import javax.swing.InputVerifier;
+import javax.swing.JComponent;
+import javax.swing.event.DocumentEvent;
+import javax.swing.event.DocumentListener;
+*/
+import javax.swing.text.Document;
+import javax.swing.text.JTextComponent;
+
+import org.netbeans.validation.api.Problems;
+import org.netbeans.validation.api.Validator;
+import org.netbeans.validation.api.ui.swing.SwingValidationGroup;
+
+/**
+ * Hook into SimpleValidation framework; validate on demand, not as a listener.
+ * Useful for the way SwingSet splits validation and decoration.
+ * @author Tim Boudreau
+ */
+// TODO: Make this independent of Document, just use a string?
+//		 Set the string on every change to text, after change needs validation?
+public class SSTextComponentValidationItem extends ValidationListener<JTextComponent>
+        //implements DocumentListener, FocusListener, Runnable
+{
+    private Validator<Document> validator;
+    private boolean hasFatalProblem = false;
+
+    public SSTextComponentValidationItem(JTextComponent component,
+										 ValidationStrategy strategy,
+										 ValidationUI validationUI,
+										 Validator<Document> validator
+	) {
+        super(JTextComponent.class, validationUI, component);
+        this.validator = validator;
+        if (strategy == null) {
+            throw new NullPointerException("strategy null");
+        }
+/*
+        component.addPropertyChangeListener("enabled", new PropertyChangeListener() {
+            public void propertyChange(PropertyChangeEvent evt) {
+                performValidation();
+            }
+        });
+        switch (strategy) {
+            case DEFAULT:
+            case ON_CHANGE_OR_ACTION:
+                component.getDocument().addDocumentListener(this);
+                break;
+            case INPUT_VERIFIER:
+                component.setInputVerifier( new InputVerifier() {
+                    @Override
+                    public boolean verify(JComponent input) {
+						performValidation();
+						return !hasFatalProblem;
+                    }
+                });
+                break;
+            case ON_FOCUS_LOSS:
+                component.addFocusListener(this);
+                break;
+        }
+*/
+        performValidation(); // Make sure any initial errors are discovered immediately.
+    }
+
+	/** just run the validator, no decoration */
+	public boolean validate() {
+		if (!SwingUtilities.isEventDispatchThread()) {
+			SwingUtilities.invokeLater(() -> validate());
+		}
+        JTextComponent component = getTarget();
+		Problems ps = new Problems();
+        validator.validate(ps, SwingValidationGroup.nameForComponent(component), component.getDocument());
+		return !ps.hasFatal();
+	}
+
+	protected boolean hasFatalProblem() {
+		return hasFatalProblem;
+	}
+
+    @Override
+    protected final void performValidation(Problems ps){
+		if (!SwingUtilities.isEventDispatchThread()) {
+			SwingUtilities.invokeLater(() -> performValidation(ps));
+		}
+        JTextComponent component = getTarget();
+        if (!component.isEnabled()) {
+            return;
+        }
+        validator.validate(ps, SwingValidationGroup.nameForComponent(component), component.getDocument());
+        hasFatalProblem = ps.hasFatal();
+    }
+
+/*
+    @Override
+    public void focusLost(FocusEvent e) {
+        performValidation();
+    }
+
+    @Override
+    public void focusGained(FocusEvent e) {
+    }
+
+    @Override
+    public void insertUpdate(DocumentEvent e) {
+        removeUpdate(e);
+    }
+
+    @Override
+    public void removeUpdate(DocumentEvent e) {
+        //Documents can be legally updated from another thread,
+        //but we will not run validation outside the EDT
+        if (!EventQueue.isDispatchThread()) {
+            EventQueue.invokeLater(this);
+        } else {
+            performValidation();
+        }
+    }
+
+    @Override
+    public void changedUpdate(DocumentEvent e) {
+        removeUpdate(e);
+    }
+
+    // See removeUpdate..
+    @Override
+    public void run() {
+        performValidation();
+    }
+*/
+}

--- a/swingset-demo/src/main/java/com/nqadmin/swingset/demo/simpval/SVUtils.java
+++ b/swingset-demo/src/main/java/com/nqadmin/swingset/demo/simpval/SVUtils.java
@@ -1,0 +1,104 @@
+/* *****************************************************************************
+ * Copyright (C) 2024, Prasanth R. Pasala, Brian E. Pangburn, & The Pangburn Group
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Contributors:
+ *   Prasanth R. Pasala
+ *   Brian E. Pangburn
+ *   Diego Gil
+ *   Man "Bee" Vo
+ *   Ernie R. Rael
+ * ****************************************************************************/
+package com.nqadmin.swingset.demo.simpval;
+
+import com.nqadmin.swingset.SSTextField;
+import com.nqadmin.swingset.utils.SSComponentInterface;
+import java.util.concurrent.locks.Condition;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import javax.swing.text.Document;
+import javax.swing.text.JTextComponent;
+import org.netbeans.validation.api.AbstractValidator;
+import org.netbeans.validation.api.Problems;
+import org.netbeans.validation.api.Validator;
+import org.netbeans.validation.api.ValidatorUtils;
+import org.netbeans.validation.api.conversion.Converter;
+import org.netbeans.validation.api.ui.ValidationItem;
+import org.netbeans.validation.api.ui.ValidationStrategy;
+import org.netbeans.validation.api.ui.swing.SwingComponentDecorationFactory;
+
+/**
+ * Helpers for working with Simple Validation framework.
+ */
+public class SVUtils {
+	private SVUtils() { }
+
+	/**
+	 * Should probably be from a factory.
+	 * @param comp
+	 * @param validators
+	 * @return 
+	 */
+	@SafeVarargs
+	public static SSTextComponentValidationItem createDefaultTextValidator(
+			JTextComponent comp, Validator<String>... validators
+	) {
+		Validator<String> merged = ValidatorUtils.merge(validators);
+		Validator<Document> validator = Converter.find(
+				String.class, Document.class).convert(merged);
+		SSTextComponentValidationItem valItem = new SSTextComponentValidationItem(
+				comp, ValidationStrategy.DEFAULT,
+				SwingComponentDecorationFactory.getDefault().decorationFor(comp),
+				validator);
+		return valItem;
+	}
+
+	public static StringValidator getStringValidator(Function<String, Boolean> condition,
+													 Supplier<String> problem) {
+		return new StringValidator() {
+			@Override
+			public void validate(Problems problems, String compName, String model) {
+				if(!condition.apply(model)) {
+					problems.append(problem.get());
+				}
+			}
+		};
+	}
+
+	public static ValidationItem decorator(JTextComponent jtc, StringValidator sval) {
+		SSComponentInterface ssComp = (SSComponentInterface) jtc;
+		SSTextComponentValidationItem textVali = SVUtils.createDefaultTextValidator(
+				jtc, sval);
+		SimpValValidatorDecorator deco = new SimpValValidatorDecorator(textVali);
+		ssComp.getSSCommon().setDecorator(deco);
+		ssComp.getSSCommon().setValidator(deco.getValidator());
+		return textVali;
+	}
+	
+}

--- a/swingset-demo/src/main/java/com/nqadmin/swingset/demo/simpval/SimpValValidatorDecorator.java
+++ b/swingset-demo/src/main/java/com/nqadmin/swingset/demo/simpval/SimpValValidatorDecorator.java
@@ -1,0 +1,83 @@
+/* *****************************************************************************
+ * Copyright (C) 2024, Prasanth R. Pasala, Brian E. Pangburn, & The Pangburn Group
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Contributors:
+ *   Prasanth R. Pasala
+ *   Brian E. Pangburn
+ *   Diego Gil
+ *   Man "Bee" Vo
+ *   Ernie R. Rael
+ * ****************************************************************************/
+package com.nqadmin.swingset.demo.simpval;
+
+import com.nqadmin.swingset.decorators.Decorator;
+import com.nqadmin.swingset.decorators.Validator;
+import com.nqadmin.swingset.utils.SSComponentInterface;
+
+/**
+ * A combined validator/decorator using the Simple Validation framework.
+ */
+public class SimpValValidatorDecorator implements Decorator
+{
+	private final SSTextComponentValidationItem valItem;
+
+	public SimpValValidatorDecorator(SSTextComponentValidationItem valItem) {
+		this.valItem = valItem;
+		this.validator = () -> valItem.validate();
+	}
+
+	@Override
+	public boolean decorate() {
+		valItem.performValidation();
+		return !valItem.hasFatalProblem();
+	}
+
+	@Override
+	public void install(SSComponentInterface component) {
+		// No listeners to install
+	}
+
+	@Override
+	public void uninstall() {
+	}
+
+	// TODO: this does decoration as well. Does SwingSet need a split architecture?
+	private final Validator validator;
+
+	/**
+	 * Get the SwingSet validator.
+	 * TODO: Note that this does decoration as well.
+	 * @return 
+	 */
+	public Validator getValidator() {
+		return validator;
+	}
+	
+}

--- a/swingset-demo/src/main/java/com/nqadmin/swingset/demo/simpval/StringValidator.java
+++ b/swingset-demo/src/main/java/com/nqadmin/swingset/demo/simpval/StringValidator.java
@@ -1,0 +1,50 @@
+/* *****************************************************************************
+ * Copyright (C) 2024, Prasanth R. Pasala, Brian E. Pangburn, & The Pangburn Group
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Contributors:
+ *   Prasanth R. Pasala
+ *   Brian E. Pangburn
+ *   Diego Gil
+ *   Man "Bee" Vo
+ *   Ernie R. Rael
+ * ****************************************************************************/
+package com.nqadmin.swingset.demo.simpval;
+
+import org.netbeans.validation.api.AbstractValidator;
+
+/**
+ *
+ * @author err
+ */
+public abstract class StringValidator extends AbstractValidator<String> {
+    protected StringValidator() {
+        super (String.class);
+    }
+}

--- a/swingset/src/main/java/com/nqadmin/swingset/utils/SSCommon.java
+++ b/swingset/src/main/java/com/nqadmin/swingset/utils/SSCommon.java
@@ -106,7 +106,7 @@ import com.nqadmin.swingset.decorators.Validator;
  */
 public class SSCommon implements Serializable {
 
-	private static final Boolean DISABLE_GENERAL_VALIDATION = true;
+	private static final Boolean DISABLE_GENERAL_VALIDATION = false;
 
 	/**
 	 * Document listener provided for convenience for SwingSet Components that are


### PR DESCRIPTION
The key point is that this is done without modifying either SwingSet or SimpleValidation. Run demo `Example1`, and enter "oops" as the supplier name, to see the following

![SimpleValidation](https://github.com/bpangburn/swingset/assets/20450427/2b609bb2-084a-4af5-8e6b-bc745ee0fa00)

Note that hovering the mouse over the badge on the SSTextField brings up a tool tip.