### PR TITLE
Grid colored multi key sort arrows

### DIFF
--- a/swingset/src/main/java/com/nqadmin/swingset/SSDataGrid.java
+++ b/swingset/src/main/java/com/nqadmin/swingset/SSDataGrid.java
@@ -52,10 +52,8 @@ import java.sql.JDBCType;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Calendar;
 import java.util.Collections;
 import java.util.EventObject;
-import java.util.GregorianCalendar;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -81,6 +79,7 @@ import javax.swing.SortOrder;
 import javax.swing.SwingConstants;
 import javax.swing.border.LineBorder;
 import javax.swing.table.DefaultTableCellRenderer;
+import javax.swing.table.JTableHeader;
 import javax.swing.table.TableCellRenderer;
 import javax.swing.table.TableColumn;
 import javax.swing.table.TableColumnModel;
@@ -90,6 +89,7 @@ import javax.swing.table.TableRowSorter;
 import org.apache.logging.log4j.Logger;
 
 import com.nqadmin.swingset.datasources.RowSetOps;
+import com.nqadmin.swingset.models.GridTableHeader;
 import com.nqadmin.swingset.models.SimpleComboListSwingModels;
 import com.nqadmin.swingset.utils.SSCommon;
 import com.nqadmin.swingset.utils.SSUtils;
@@ -833,6 +833,12 @@ public class SSDataGrid extends JTable {
 	@Override
 	protected SSTableModel createDefaultDataModel() {
 		return new SSTableModel();
+	}
+
+	/** {@inheritDoc } */
+	@Override
+	protected JTableHeader createDefaultTableHeader() {
+		return new GridTableHeader(columnModel);
 	}
 
 	/**

--- a/swingset/src/main/java/com/nqadmin/swingset/models/GridTableCellHeaderRenderer.java
+++ b/swingset/src/main/java/com/nqadmin/swingset/models/GridTableCellHeaderRenderer.java
@@ -1,0 +1,250 @@
+/*
+ * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+//package sun.swing.table;
+package com.nqadmin.swingset.models;
+
+//import sun.swing.DefaultLookup;
+
+import java.awt.Component;
+import java.awt.Color;
+import java.awt.FontMetrics;
+import java.awt.Graphics;
+import java.awt.Insets;
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.io.Serializable;
+
+import javax.swing.*;
+import javax.swing.plaf.UIResource;
+import javax.swing.border.Border;
+import javax.swing.table.*;
+
+/**
+ * Derived from sun.swing.table.DefaultTableCellHeaderRenderer.
+ */
+
+@SuppressWarnings("serial") // JDK-implementation class
+public class GridTableCellHeaderRenderer extends DefaultTableCellRenderer
+        implements UIResource {
+    private boolean horizontalTextPositionSet;
+    private Icon sortArrow;
+    private EmptyIcon emptyIcon = new EmptyIcon();
+
+	static {
+		UIManager.put("Table.ascendingSortIcon-1", new SortArrowIcon(true, Color.green));
+		UIManager.put("Table.ascendingSortIcon-2", new SortArrowIcon(true, Color.orange));
+		UIManager.put("Table.descendingSortIcon-1", new SortArrowIcon(false, Color.green));
+		UIManager.put("Table.descendingSortIcon-2", new SortArrowIcon(false, Color.orange));
+
+		Icon natural = UIManager.getIcon("Table.naturalSortIcon");
+		UIManager.put("Table.naturalSortIcon-1", natural);
+		UIManager.put("Table.naturalSortIcon-2", natural);
+
+		//UIManager.put("TableHeader.rightAlignSortArrow", true);
+	}
+
+    public GridTableCellHeaderRenderer() {
+        setHorizontalAlignment(JLabel.CENTER);
+    }
+
+    public void setHorizontalTextPosition(int textPosition) {
+        horizontalTextPositionSet = true;
+        super.setHorizontalTextPosition(textPosition);
+    }
+
+    public Component getTableCellRendererComponent(JTable table, Object value,
+            boolean isSelected, boolean hasFocus, int row, int column) {
+        Icon sortIcon = null;
+
+        boolean isPaintingForPrint = false;
+
+        if (table != null) {
+            JTableHeader header = table.getTableHeader();
+            if (header != null) {
+                Color fgColor = null;
+                Color bgColor = null;
+                if (hasFocus) {
+                    fgColor = DefaultLookup.getColor(this, ui, "TableHeader.focusCellForeground");
+                    bgColor = DefaultLookup.getColor(this, ui, "TableHeader.focusCellBackground");
+                }
+                if (fgColor == null) {
+                    fgColor = header.getForeground();
+                }
+                if (bgColor == null) {
+                    bgColor = header.getBackground();
+                }
+                setForeground(fgColor);
+                setBackground(bgColor);
+
+                setFont(header.getFont());
+
+                isPaintingForPrint = header.isPaintingForPrint();
+            }
+
+            if (!isPaintingForPrint && table.getRowSorter() != null) {
+                if (!horizontalTextPositionSet) {
+                    // There is a row sorter, and the developer hasn't
+                    // set a text position, change to leading.
+                    setHorizontalTextPosition(JLabel.LEADING);
+                }
+                Object[] result = getColumnSortOrder(table, column);
+                SortOrder sortOrder = (SortOrder) result[0];
+				int keyIndex = (int) result[1];
+				String iconLookupKey = "";
+                if (sortOrder != null) {
+                    switch(sortOrder) {
+                    case ASCENDING:
+                        iconLookupKey = "Table.ascendingSortIcon";
+                        break;
+                    case DESCENDING:
+                        iconLookupKey = "Table.descendingSortIcon";
+                        break;
+                    case UNSORTED:
+                        iconLookupKey = "Table.naturalSortIcon";
+                        break;
+                    }
+					if (keyIndex != 0)
+						iconLookupKey += "-" + keyIndex;
+					sortIcon = DefaultLookup.getIcon(this, ui, iconLookupKey);
+                }
+            }
+        }
+
+        setText(value == null ? "" : value.toString());
+        setIcon(sortIcon);
+        sortArrow = sortIcon;
+
+        Border border = null;
+        if (hasFocus) {
+            border = DefaultLookup.getBorder(this, ui, "TableHeader.focusCellBorder");
+        }
+        if (border == null) {
+            border = DefaultLookup.getBorder(this, ui, "TableHeader.cellBorder");
+        }
+        setBorder(border);
+
+        return this;
+    }
+
+	/** return array { sortOrder, keyIndex } or null if none. */
+    // public static SortOrder getColumnSortOrder(JTable table, int column) {
+    private static Object[] getColumnSortOrder(JTable table, int column) {
+        Object[] rv = new Object[] {null, 0};
+        if (table == null || table.getRowSorter() == null) {
+            return rv;
+        }
+        java.util.List<? extends RowSorter.SortKey> sortKeys =
+            table.getRowSorter().getSortKeys();
+		for (int i = 0; i < sortKeys.size(); i++) {
+			RowSorter.SortKey sortKey = sortKeys.get(i);
+			if (i == 0 && sortKey.getSortOrder() == SortOrder.UNSORTED)
+				return rv; // If first key is unsorted, then there's no sort.
+			if (sortKey.getColumn() == table.convertColumnIndexToModel(column)) {
+				return new Object[] { sortKey.getSortOrder(), i };
+			}
+		}
+        return rv;
+    }
+
+    @Override
+    public void paintComponent(Graphics g) {
+        boolean b = DefaultLookup.getBoolean(this, ui,
+                "TableHeader.rightAlignSortArrow", false);
+        if (b && sortArrow != null) {
+            //emptyIcon is used so that if the text in the header is right
+            //aligned, or if the column is too narrow, then the text will
+            //be sized appropriately to make room for the icon that is about
+            //to be painted manually here.
+            emptyIcon.width = sortArrow.getIconWidth();
+            emptyIcon.height = sortArrow.getIconHeight();
+            setIcon(emptyIcon);
+            super.paintComponent(g);
+            Point position = computeIconPosition(g);
+            sortArrow.paintIcon(this, g, position.x, position.y);
+        } else {
+            super.paintComponent(g);
+        }
+    }
+
+    private Point computeIconPosition(Graphics g) {
+        FontMetrics fontMetrics = g.getFontMetrics();
+        Rectangle viewR = new Rectangle();
+        Rectangle textR = new Rectangle();
+        Rectangle iconR = new Rectangle();
+        Insets i = getInsets();
+        viewR.x = i.left;
+        viewR.y = i.top;
+        viewR.width = getWidth() - (i.left + i.right);
+        viewR.height = getHeight() - (i.top + i.bottom);
+        SwingUtilities.layoutCompoundLabel(
+            this,
+            fontMetrics,
+            getText(),
+            sortArrow,
+            getVerticalAlignment(),
+            getHorizontalAlignment(),
+            getVerticalTextPosition(),
+            getHorizontalTextPosition(),
+            viewR,
+            iconR,
+            textR,
+            getIconTextGap());
+        int x = getWidth() - i.right - sortArrow.getIconWidth();
+        int y = iconR.y;
+        return new Point(x, y);
+    }
+
+    @SuppressWarnings("serial") // JDK-implementation class
+    private static class EmptyIcon implements Icon, Serializable {
+        int width = 0;
+        int height = 0;
+        public void paintIcon(Component c, Graphics g, int x, int y) {}
+        public int getIconWidth() { return width; }
+        public int getIconHeight() { return height; }
+    }
+
+	static class DefaultLookup {
+		static Color getColor(JComponent c, Object ui, String key)
+		{
+			Color color = UIManager.getColor(key);
+			return color;
+		}
+		static Icon getIcon(JComponent c, Object ui, String key)
+		{
+			Icon icon = UIManager.getIcon(key);
+			return icon;
+		}
+		static Border getBorder(JComponent c, Object ui, String key)
+		{
+			Border border = UIManager.getBorder(key);
+			return border;
+		}
+		static boolean getBoolean(JComponent c, Object ui, String key, boolean defaultValue)
+		{
+			boolean flag = UIManager.getBoolean(key);
+			return flag;
+		}
+	}
+}

--- a/swingset/src/main/java/com/nqadmin/swingset/models/GridTableHeader.java
+++ b/swingset/src/main/java/com/nqadmin/swingset/models/GridTableHeader.java
@@ -1,0 +1,63 @@
+/* *****************************************************************************
+ * Copyright (C) 2024, Prasanth R. Pasala, Brian E. Pangburn, & The Pangburn Group
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Contributors:
+ *   Prasanth R. Pasala
+ *   Brian E. Pangburn
+ *   Diego Gil
+ *   Man "Bee" Vo
+ *   Ernie R. Rael
+ * ****************************************************************************/
+package com.nqadmin.swingset.models;
+
+import javax.swing.table.JTableHeader;
+import javax.swing.table.TableCellRenderer;
+import javax.swing.table.TableColumnModel;
+
+/**
+ * Use with SSDataGrid.
+ */
+@SuppressWarnings("serial")
+public class GridTableHeader extends JTableHeader {
+
+	public GridTableHeader() {
+	}
+
+	public GridTableHeader(TableColumnModel cm) {
+		super(cm);
+	}
+
+	/** {@inheritDoc } */
+	@Override
+	protected TableCellRenderer createDefaultRenderer() {
+		return new GridTableCellHeaderRenderer();
+	}
+
+}

--- a/swingset/src/main/java/com/nqadmin/swingset/models/SortArrowIcon.java
+++ b/swingset/src/main/java/com/nqadmin/swingset/models/SortArrowIcon.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2005, 2014, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+//package sun.swing.icon;
+package com.nqadmin.swingset.models;
+
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Graphics;
+import java.io.Serializable;
+import javax.swing.Icon;
+import javax.swing.UIManager;
+import javax.swing.plaf.UIResource;
+
+/**
+ * Sorting icon.
+ * Derived from java.desktop/sun/swing/icon/SortArrowIcon.java.
+ */
+@SuppressWarnings("serial") // JDK-implementation class
+public class SortArrowIcon implements Icon, UIResource, Serializable {
+    // Height of the arrow, the width is ARROW_HEIGHT
+    private static final int ARROW_HEIGHT = 5;
+
+    // Amount of pad to left of arrow
+    private static final int X_PADDING = 7;
+
+    // Sort direction
+    private boolean ascending;
+
+    // The Color to use, may be null indicating colorKey should be used
+    private Color color;
+
+    // If non-null indicates the color should come from the UIManager with
+    // this key.
+    private String colorKey;
+
+    /**
+     * Creates a <code>SortArrowIcon</code>.
+     *
+     * @param ascending if true, icon respresenting ascending sort, otherwise
+     *        descending
+     * @param color the color to render the icon
+     */
+    public SortArrowIcon(boolean ascending, Color color) {
+        this.ascending = ascending;
+        this.color = color;
+        if (color == null) {
+            throw new IllegalArgumentException();
+        }
+    }
+
+    /**
+     * Creates a <code>SortArrowIcon</code>.
+     *
+     * @param ascending if true, icon respresenting ascending sort, otherwise
+     *        descending
+     * @param colorKey the key used to find color in UIManager
+     */
+    public SortArrowIcon(boolean ascending, String colorKey) {
+        this.ascending = ascending;
+        this.colorKey = colorKey;
+        if (colorKey == null) {
+            throw new IllegalArgumentException();
+        }
+    }
+
+    public void paintIcon(Component c, Graphics g, int x, int y) {
+        g.setColor(getColor());
+        int startX = X_PADDING + x + ARROW_HEIGHT / 2;
+        if (ascending) {
+            int startY = y;
+            g.fillRect(startX, startY, 1, 1);
+            for (int line = 1; line < ARROW_HEIGHT; line++) {
+                g.fillRect(startX - line, startY + line,
+                           line + line + 1, 1);
+            }
+        }
+        else {
+            int startY = y + ARROW_HEIGHT - 1;
+            g.fillRect(startX, startY, 1, 1);
+            for (int line = 1; line < ARROW_HEIGHT; line++) {
+                g.fillRect(startX - line, startY - line,
+                           line + line + 1, 1);
+            }
+        }
+    }
+
+    public int getIconWidth() {
+        return X_PADDING + ARROW_HEIGHT * 2;
+    }
+
+    public int getIconHeight() {
+        return ARROW_HEIGHT + 2;
+    }
+
+    private Color getColor() {
+        if (color != null) {
+            return color;
+        }
+        return UIManager.getColor(colorKey);
+    }
+}


### PR DESCRIPTION
Extend sort infrastructure to handle multi-key arrows.
Color shows sort order, configure colors in GridTableCellHeaderRenderer.
Could use gray colors.

![multi-key-sort](https://github.com/bpangburn/swingset/assets/20450427/5a13120c-11d5-447a-8287-8eedfef2b9d8)

