### PR TITLE
extend SSVersion to handle a pre-release component

### DIFF
--- a/swingset/src/main/java/com/nqadmin/swingset/utils/SSVersion.java
+++ b/swingset/src/main/java/com/nqadmin/swingset/utils/SSVersion.java
@@ -55,6 +55,13 @@ import org.apache.logging.log4j.Logger;
  * Version string is of the form "{@literal <digits>.<digits>.<digits>-SNAPSHOT}"
  * where "-SNAPSHOT" is optional and missing components are 0.
  * <p>
+ * In addition, a version may end in {@literal -<anything>} and is
+ * considered pre-release. The pre-release string is converted to lower case.
+ * For comparisons regular-release {@literal >} pre-release {@literal >} snapshot.<br>
+ * For example 1.2.3 {@literal >} 1.2.3-RC1 {@literal >} 1.2.3-SNAPSHOT.<br>
+ * For example 1.2.3-RC2 {@literal >} 1.2.3-RC1
+ * <p>
+ * 
  *{@linkplain SSVersion} is comparable, for example,
  * <pre>
  * {@code
@@ -108,16 +115,49 @@ public class SSVersion implements Comparable<SSVersion> {
 		return parse(sVer);
 	}
 
+	// These three values are used to specify the type of version, used for compare
+	private static final int VER_REGULAR = 3;
+	private static final int VER_PRE_RELEASE = 2;
+	private static final int VER_SNAPSHOT = 1;
+
 	/** Version number components. */
 	private final List<Integer> versionSequence;
 	/** Is the version a snapshot? */
 	private final boolean isSnapshot;
+	private final String preRelease;
+	private final int versionType;
 
-	private SSVersion(List<Integer> _versionSequence, boolean _isSnapshot) {
+	private SSVersion(List<Integer> _versionSequence, boolean _isSnapshot, String _pre) {
 		versionSequence = new ArrayList<>(_versionSequence);
 		isSnapshot = _isSnapshot;
+		preRelease = _pre.toLowerCase();
+		versionType = !preRelease.isEmpty() ? VER_PRE_RELEASE
+				: isSnapshot ? VER_SNAPSHOT : VER_REGULAR;
 	}
 
+	/**
+	 * Check if this release is a "-SNAPSHOT".
+	 * @return true if snapshot
+	 */
+	public boolean isSnapshot() {
+		return isSnapshot;
+	}
+
+	/**
+	 * Check if this release is a pre-release; has "-xxx" appended.
+	 * @return true if pre-release
+	 */
+	public boolean isPreRelease() {
+		return !preRelease.isEmpty();
+	}
+
+	/**
+	 * Get the lower case pre-release string; empty if not a prerelease.
+	 * @return pre-release string as lower case
+	 */
+	public String preRelease() {
+		return preRelease;
+	}
 	/** {@inheritDoc} */
 	@Override
 	public int compareTo(SSVersion o) {
@@ -127,11 +167,11 @@ public class SSVersion implements Comparable<SSVersion> {
 				return diff;
 			}
 		}
-		if (isSnapshot == o.isSnapshot) {
-			return 0;
+		// The 'x.y.z' parts are equal
+		if (versionType == VER_PRE_RELEASE && o.versionType == VER_PRE_RELEASE) {
+			return preRelease.compareToIgnoreCase(o.preRelease);
 		}
-		// If this is a snapshot, then it is "smaller" than the other.
-		return isSnapshot ? -1 : 1;
+		return versionType - o.versionType;
 	}
 
 	/** Parse a version string; return parse of "0.0.0-SNAPSHOT" if parse error.
@@ -141,18 +181,34 @@ public class SSVersion implements Comparable<SSVersion> {
 	private static SSVersion parse(String _sVer) {
 		String sVer = _sVer != null ? _sVer : ERROR_VERSION;
 		boolean isSnap = false;
+		boolean is_error = false;
+		String pre = "";
 		if (sVer.endsWith(SNAP)) {
+			// strip off the "-SNAPSHOT"
 			sVer = sVer.substring(0, sVer.length() - SNAP.length());
 			isSnap = true;
 		}
-		Matcher m = Pattern.compile("^(\\d+)(\\.(\\d+))?(\\.(\\d+))?$").matcher(sVer);
-		// group({1, 3, 5}) are the components
-		if (m.matches()) {
-			List<Integer> seq = new ArrayList<>();
-			seq.add(Integer.valueOf(m.group(1)));
-			seq.add(m.group(3) != null ? Integer.valueOf(m.group(3)) : (Integer)0);
-			seq.add(m.group(5) != null ? Integer.valueOf(m.group(5)) : (Integer)0);
-			return new SSVersion(seq, isSnap);
+		int preIdx = sVer.indexOf('-');
+		if (preIdx >= 0) {
+			// remove the pre release indicator
+			if (preIdx + 1 == sVer.length() || isSnap) {
+				// a version tag of only "-" or a x.y.z-pre-SNAPSHOT
+				is_error = true;
+			} else {
+				pre = sVer.substring(preIdx + 1);
+				sVer = sVer.substring(0, preIdx);
+			}
+		}
+		if (!is_error) {
+			Matcher m = Pattern.compile("^(\\d+)(\\.(\\d+))?(\\.(\\d+))?$").matcher(sVer);
+			// group({1, 3, 5}) are the components
+			if (m.matches()) {
+				List<Integer> seq = new ArrayList<>();
+				seq.add(Integer.valueOf(m.group(1)));
+				seq.add(m.group(3) != null ? Integer.valueOf(m.group(3)) : (Integer)0);
+				seq.add(m.group(5) != null ? Integer.valueOf(m.group(5)) : (Integer)0);
+				return new SSVersion(seq, isSnap, pre);
+			}
 		}
 		logger.error(() -> "Version parse error: " + _sVer);
 		return parse(ERROR_VERSION);
@@ -182,7 +238,8 @@ public class SSVersion implements Comparable<SSVersion> {
 		return versionSequence.get(0)
 				+ "." + versionSequence.get(1)
 				+ "." + versionSequence.get(2)
-				+ (isSnapshot ? "-SNAPSHOT" : "");
+				+ (isSnapshot ? "-SNAPSHOT" : "")
+				+ (preRelease.isEmpty() ? "" : "-" + preRelease());
 	}
 
 	/** {@inheritDoc} */

--- a/swingset/src/test/java/com/nqadmin/swingset/utils/SSVersionTest.java
+++ b/swingset/src/test/java/com/nqadmin/swingset/utils/SSVersionTest.java
@@ -88,6 +88,47 @@ public class SSVersionTest {
 		assertTrue(v1.compareTo(SSVersion.get("2.2.3")) < 0);
 		assertTrue(v1.compareTo(SSVersion.get("1.2.4")) < 0);
 		assertTrue(v1.compareTo(SSVersion.get("1.2.2")) > 0);
-	}
 
+		assertEquals(vNull, SSVersion.get("1.2.3-"));
+		assertEquals(vNull, SSVersion.get("1.2.3-RC1-SNAPSHOT"));
+
+		SSVersion vrc1 = SSVersion.get("1.2.3-RC1");
+		SSVersion vrc2 = SSVersion.get("1.2.3-RC2");
+		SSVersion vreg = SSVersion.get("1.2.3");
+		SSVersion vsnap = SSVersion.get("1.2.3-SNAPSHOT");
+
+		assertTrue(vrc1.preRelease().equals("rc1"));
+		assertTrue(vrc2.preRelease().equals("rc2"));
+
+		assertFalse(vreg.isPreRelease());
+		assertFalse(vreg.isSnapshot());
+		assertTrue(vreg.preRelease().isEmpty());
+
+		assertTrue(vrc1.isPreRelease());
+		assertFalse(vrc1.isSnapshot());
+		assertFalse(vrc1.preRelease().isEmpty());
+
+		assertFalse(vsnap.isPreRelease());
+		assertTrue(vsnap.isSnapshot());
+		assertTrue(vsnap.preRelease().isEmpty());
+
+		SSVersion vrc2B = SSVersion.get("1.2.3-RC2");
+		SSVersion vregB = SSVersion.get("1.2.3");
+		SSVersion vsnapB = SSVersion.get("1.2.3-SNAPSHOT");
+
+		assertTrue(vrc2.compareTo(vrc2B)   == 0);
+		assertTrue(vreg.compareTo(vregB)   == 0);
+		assertTrue(vsnap.compareTo(vsnapB) == 0);
+
+		assertTrue(vrc2.compareTo(vrc1) > 0);
+		assertTrue(vrc1.compareTo(vrc2) < 0);
+
+		assertTrue(vreg.compareTo(vrc1)  > 0);
+		assertTrue(vreg.compareTo(vsnap) > 0);
+		assertTrue(vrc1.compareTo(vreg)  < 0);
+		assertTrue(vsnap.compareTo(vreg) < 0);
+
+		assertTrue(vrc1.compareTo(vsnap) > 0);
+		assertTrue(vsnap.compareTo(vrc1) < 0);
+	}
 }


### PR DESCRIPTION
Something like `-xxx` or `-RC1` can be appended to a version number as a pre-release tag.