### PR TITLE
Nav up/down. DataNav set/get deprecate. Missing things.

### DIFF
--- a/.hgignore
+++ b/.hgignore
@@ -9,5 +9,5 @@ syntax: glob
 *.rej
 
 syntax: rootglob
-NOTES-LOCAL
+NOTES/DOING
 tags

--- a/NOTES/TODO
+++ b/NOTES/TODO
@@ -1,0 +1,414 @@
+================================================================================
+============================= BUGS =============================================
+================================================================================
+
+---
+If at bottom of stack, then Redo to an error, swithes from canNavigate btns to
+only RevertChanges btn. There is a brief flash of the commit button on the way,
+minor issue to ignore for now.
+
+================================================================================
+============================= HMMMM ============================================
+================================================================================
+
+Add variable SORT_REMOVE_KEYS to SSDataGrid, an option eventually.
+
+---
+Should the methods in SSDataNavigator that delegate to getNavigatorActions()
+be deprecated? If NavigatorActions are considered a model, then there's
+precedence to keep them.
+
+---
+re-indent swingset
+// vi:set ts=8 sw=4 sts=4 noet:
+
+---
+catch SQLFeatureNotSupportedException and do conversion manually? Option?
+Or run a program that checks what works and produces something that can be
+given to SS for configuration.
+
+---
+In Field's componentValidate "null&&nullOK" check.
+What can be done as default for SSComponent in general?
+
+---
+TextDecorator capable SSTextField.
+
+---
+NumberField
+    The use of Locale is inconsistent
+
+---
+Cleanup
+    more logging for null formatter switching
+    Error in not edit and display formatters
+    Clean up FormatterAssist, SSNumberFormatter, 
+
+---
+Fixup SSFormattedTextField to consider user's containsUserText.
+
+---
+There's
+    formatterAssist::getFormatLiterals - NOT USED
+    getDecimalFormatSymbols - for getLiterals?
+
+---
+Fixup SSFormattedTextField to consider user's containsUserText.
+Optimize contains user text.
+
+---
+stringToValue/valueToString
+    Look at the stringToValue/valueToString stuff in FormatterAssist. Get rid of it?
+    Examine MaskFormatter stringToValue. Add verifier check for getAllowNull()
+
+    DefaultFormatter::isValidEdit
+        InternationalFormatter::stringToValue(text)
+            NumberForatter::stringToValue(text, format)
+                parseObject thows, caught in isValidEdit
+    SSNumberFormatter::valueToString
+
+---
+utils/SSMsg - NOTE: RowSetOps CreateMessage(RSC)
+    Msg(text, (rsc) -> rsc.getBoundColumnText())
+    Msg(text, List.of((rsc) -> rsc.getBoundColumnText())) or "new []"?
+
+---
+Examine SSFormattedTextField::updateSSComponent
+
+---
+Use DateTime for MaskFormatter's converter.
+Use DateTimeFormatter instead of DateFormatter in Fields, consider
+relationship with DateTime.java.
+
+================================================================================
+=========================== CLEANUP ============================================
+================================================================================
+
+Get rid of the @author tags.
+
+Navigator
+    - The method "setV3Buttons()" has been mentioned. But the real method of interest is probably "setAutoCommit()". When this is set, the navigation actions remain enabled when the rowset is modified; navigating away from the row does commit the modified rowset. "setV3Buttons()" does "setAutoCommit()" and also always have commit/revert enabled even if nothing is modified.
+
+    - Consider that up/down arrows now optionally do next-row/prev-row. How about, when AutoCommit is off, doing Shift-Ctrl-up/down (or whatever) does commit then move. Then the convenience of autoCommit is still available. And if people just started doing Shift-Ctrl-up all the time, then ...
+
+    - There are some methods in SSDataNavigator, like setModification, which are really NavigateActions behavior. Currently
+        setModification(boolean modOK) { navActs.setModification(modOK); }
+    They should be deprecated and removed in a future release. Want to deprecate them for 4.1?
+
+    - The visual arrows show left/right, but the keys are up/down. Are there any button pngs around in the same style that display up/down? Maybe at some point...
+
+---
+Examine ConvertType both to/from convert?
+
+---
+Rename convertObjectType to convertToType, or convertToJdbcType
+
+---
+Add verifier to JTextField.
+
+---
+Broader use of RSC
+Format field in RSC? For output format. (parse can be multiple)
+
+---
+setValidator in SSCommon, but not SSComponentInterface. Needed this in general?
+
+---
+Make getSSCommon final. Rename ssCommon to ssCommonUseGetSSCommon.
+
+---
+Get rid of all direct row set access; always go through RowSetOps.
+
+In SSCommon::undoRedoUpdateObject: getRowSet().updateObject(getBoundColumnIndex(), value);
+
+
+--- ?????
+Change to use SSFTF
+The DATE/TIMESTAMP in a JTextField has the problem of ignoring errors in format.
+Play with example3. Hit next on invalid value. 
+
+NOTE: There's an ignored exception thrown by
+Date/Time/Timestamp/getSQLDate.valueOf.
+
+---
+Is this about switching rowset? Might have to do with switching rowset in navigator.
+
+NavigateActions monitors a single RowSet. 1 - 1
+SSDataNavigator works on a given RowSet. can change the rowset
+
+Could have intermediate that can plug into SSDataNavigator actions don't change.
+Need to update Action/model state when Rowset changes.
+
+---
+UIManager.getLookAndFeel().provideErrorFeedback(JFormattedTextField.this);
+
+---
+Examine where conversions are used. And the conversion. Work this into 
+jdbc spec and behavior spec.
+
+---
+Add Calendar conversions? Skip it, go directly to java.time.
+
+---
+
+
+
+================================================================================
+=========================== OPTIONS ============================================
+================================================================================
+
+
+---
+Allow navigation away from error field. There can be several fields with red/yellow.
+Prevent navigation away from record with invalid field. SSFTF/SSTF consistent
+
+---
+Option to enable/disable verifier/focus-change. Globally, per window, per component.
+Window can have a lookup.
+
+================================================================================
+=========================== FEATURES ===========================================
+================================================================================
+
+Database update frequency, YELLOW STATE
+    Question about commitsOnValidEdit currently set to true (matches mask default I
+    think). So every keystroke causes database update. Without this wait for focus
+    change or return, but then the visible data is out out sync. Could have a
+    border, like yellow, that means the data looks ok so far, but hasn't been sent
+    to the database.
+
+    NOTE: every keystroke that's valid is a database write.
+    Safest, but might want to only write if loose focus,
+    or many seconds have gone by, or shutdown. Maybe an option.
+
+---
+
+TODO: Allow user to dynamically select input mask/format. Like Date style
+Field tooltip with format/...
+
+============================================================================
+============================ ARCHITECTURE ==================================
+============================================================================
+
+============== EVENTS
+
+Consider
+SSCheckBoxListener - does the decorator get called? Allthough either true/false
+is valid, there could be an interactions of components and this field
+should be marked?
+
+---
+Each SSComponent has getSSComponentListener. This listener, at lease for SSTF,
+may do postRowSetModifiedError. Explore...
+
+---
+postRowSetModified (not with Error) is only done from RowSetOps.
+
+---
+In NavigateActions.undoRedo after navActs.doUndoRedo() the database is
+updated directly, then issueRowChanged()
+    -->rowSetListener.rowChanged()-->invokeLater(updateSSComponent).
+So need to defer checking sscomponent valid and then
+posting modification messages.
+
+============== OPTIONS
+
+try to get rid of all the setters. cleanField/decorator/validator/...
+If all these items are Interfaces, then can use Lookup. Have a single
+method, e.g. addOp, that puts something into and/or replaces it in the
+Lookup. And get rid of the functions that can be overridden. After call
+to superclass, do addOp to replace it with "our".
+
+cleanField is currently method that's overridden. setValue(getAllowNull() ? null : 777)
+Could have map "Supplier<val>", look it up by class? Or maybe constructor
+    // maybe Function<SSComponent,Object> cleanFieldOp;
+    // maybe Runnable cleanFieldOp;
+    MyField(...) { // CONSTRUCTOR
+        ///// setCleanField((comp)->setValue(comp.getAllowNull() ? null : 777));
+        setCleanField(()->getAllowNull() ? null : 777); // or "... this.getAllowNull() ? ..."
+        // used like setValue(cleanFieldOp.get())
+    }
+    protected Supplier<?> cleanFieldOp;
+    private setCleanField(Supplier<?> cleanFieldOp) {
+        // Overwrites setting by superclasses.
+        this.cleanFieldOp = cleanFieldOp;
+    }
+    final public void cleanField() { // want final in SSComponent, but can't do it
+        if (xxx = Lookup(CleanField.class))
+            xxx.run();
+        //else if (cleanFieldOp)
+        //    cleanFieldOp.run();
+    }
+Maybe in SSCommon only, final cleanField(lookup...).
+
+Or just keep cleanField as is.
+
+Might want to specify cleanFieldOp per component, kind of like the way decorator specified.
+Or have Interface CleanFieldOp, add it to components lookup. First check lookup, then 
+SS-5 commit with some 4.1 applicable fixes
+
+
+============== ANNOTATIONS
+
+Have an annotation, e.g. @SSCompMethod NewM() {...}, used on something in SSCommon, and that
+automagically becomes "default NewM() { getSSCommon.NewM(); }" really want these things
+to be "final" in SSComponent.
+
+============== EVENTBUS
+
+EventBus replacement
+    rxjava as event bus the right way
+    https://kau.sh/blog/implementing-an-event-bus-with-rxjava-rxbus/
+    https://medium.com/dionysis-lorentzos-blog/rxjava-as-event-bus-the-right-way-10a36bdd49ba
+    https://metova.com/how-to-use-rxjava-as-an-event-bus/
+    https://medium.com/android-news/super-simple-event-bus-with-rxjava-and-kotlin-f1f969b21003
+
+============== CONVERT
+
+Allow character conversions to whatever.
+
+https://stackoverflow.com/questions/29773390/getting-the-date-from-a-resultset-for-use-with-java-time-classes
+
+Today most of us are using JDBC 4.2 compliant drivers, which improves the
+situation quite a bit compared to the answers from 2015.
+
+To get a LocalDate from your result set:
+
+LocalDate dateFromDatabase = yourResultSet.getObject(yourColumnIndex, LocalDate.class);
+
+or
+
+LocalDate dateFromDatabase = yourResultSet.getObject("yourColumnLabel", LocalDate.class);
+
+No new method has been added to ResultSet for this to work. The getObject method
+was there all the time. The new thing is that since JDBC 4.2 it accepts
+LocalDate.class as the second argument and returns a LocalDate. The above works
+when the query returns a column with SQL datatype date (really the JDBC type
+counts, but they tend to agree).
+
+You can pass classes of other java.time types too. And get the corresponding type back. For example:
+
+OffsetDateTime dateTimeFromDatabase
+        = yourResultSet.getObject(yourTimestampWithTimeZoneColumnIndex, OffsetDateTime.class);
+
+The java.time types to use are:
+
+SQL datatype            | java.time type
+------------------------+-----------------------------------------------------------
+date                    | LocalDate
+time                    | LocalTime
+timestamp               | LocalDateTime
+timestamp with timezone | Officially OffsetDateTime; many drivers accept Instant too
+time with timezone      | OffsetTime
+
+For passing the other way, from Java to your database (for use as query
+parameters or for storing) PreparedStatement.setObject now accepts objects of
+the above java.time types too. Since you are passing an object of a type, there
+is no need for a separate type parameter when going this way.
+
+============= DATETIME and/or _WITH_TIMEZONE
+
+Some of the conversions in convertType, while understandable, maybe shouldn't be there
+https://stackoverflow.com/questions/29773390/getting-the-date-from-a-resultset-for-use-with-java-time-classes
+For example converting date to timestamp uses zero for time. Not precise.
+
+Can probably just get rid of the Date, since JDBC has interop
+
+Date <--> LocalDate
+=============
+    https://stackoverflow.com/questions/33066904/localdate-to-java-util-date-and-vice-versa-simplest-conversion
+
+java.util.Date.from(    // Convert from modern java.time class to troublesome old
+                        // legacy class.  DO NOT DO THIS unless you must, to inter
+                        // operate with old code not yet updated for java.time.
+    myLocalDate         // `LocalDate` class represents a date-only, without
+                        // time-of-day and without time zone nor offset-from-UTC. 
+    .atStartOfDay(      // Let java.time determine the first moment of the day on
+                        // that date in that zone. Never assume the day starts at 00:00:00.
+        ZoneId.of( "America/Montreal" ) // Specify time zone using proper name in
+                                        //`continent/region` format, never 3-4
+                                        // letter pseudo-zones such as “PST”, “CST”, “IST”. )                   // Produce a `ZonedDateTime` object. 
+    .toInstant()        // Extract an `Instant` object, a moment always in UTC.
+)
+
+
+Retrieve LocalDate from result set
+    https://stackoverflow.com/questions/51632735/jdbc-result-set-retrieve-localdatetime
+
+Database support for timstamp with timezone/offset
+    https://github.com/hibernate/hibernate-orm/discussions/4201
+        Oracle/H2 supports them
+        Postgress supports by converting to UTC
+
+Hibernate 6 has incubating support. It has a split into two columns option.
+"When configuring TimeZoneStorageType.COLUMN, Hibernate stores the timestamp
+without timezone information and the timezone’s offset to UTC in separate
+database columns."
+    https://thorben-janssen.com/hibernate-6-offsetdatetime-and-zoneddatetime/
+
+=============KEYS
+
+Multi column keys
+
+================================================================================
+=========================== DID ================================================
+================================================================================
+
+!!! customInit called from constructor because of ssCommon = new SSCommon(this);
+Implement getSSCommon() creates a "constructingSSCommon" and saved from constructor,
+like SSTextField.
+TEST: public SSFormattedTextField(final Format _format) {
+
+---
+Added getSSCommon().decorate() at both exits from "value" prop change listener,
+this made the Number stuff work easily.
+ComponentValidate is called a lot
+Would like to simplify when it's called.
+
+---
+Problem entering decimal point
+Throw ParseException if not full string.
+    if AllowInvalid == true, then in SSNumberFormatter::stringToValue require parse full string.
+
+    WEIRD: in integer field, there's a bunch of numbers shown, with cursor in the
+    middle, enter '.' and all the after the '.' are gone. Would think that '.' is
+    invalid. Can't really have a decimal point in an integer.
+
+Fixed by SSNumberFormatter::stringToValue throwing ParseException if null and not allow null.
+    SSCurrencyField
+        selectall, backspace, goes red. Do refresh/reload current record, stays red.
+        Focus change doesn't fix it. Make it green, e.g. enter 0. Then refresh/reload DTRT.
+
+    Currency field.
+        Select all, enter 'x', ESC, back to full number.
+        Select all, enter space, ESC, stays at space.
+        Select all, enter space, enter 'x', ESC, back to space.
+---
+Surprisingly, found what I think is an ancient bug in SSCurrencyField. With the
+input "1,555,666,777,888,999,234,567.123", this stuffed Double into the database;
+should be java BigDecimal. Simple fix.
+
+---
+Add a New Record - BUG: needs to clear undo/redo record.
+    Probably just do "freshRow()" in NavigateActions::NavAddAction().
+Basically, but a little messy requriring nested invokeLater
+---
+Add checkDriverConvertToType() to CnvertType? Not exactly "Driver".
+Part of some DB config? (autogenerated by checkDB script/test)
+
+    assertConvertToType/checkConvertToType.
+
+---
+During undo/redo, ex1. Going to an error state leaves commit on.
+Undo/redo may need to do postRowSetModified*
+
+NOTE: undo/redo SSCommon.actionPerformed catches/logs SQLException,
+      no other handling of error.
+
+    In NavigateActions.undoRedo after navActs.doUndoRedo() the database is
+    updated directly, then issueRowChanged()
+        -->rowSetListener.rowChanged()-->invokeLater(updateSSComponent).
+    So need to defer checking sscomponent valid and then
+    posting modification messages.
+
+Fixed with postRowSetUndoRedo().

--- a/swingset-demo/src/main/java/com/nqadmin/swingset/demo/Example1.java
+++ b/swingset-demo/src/main/java/com/nqadmin/swingset/demo/Example1.java
@@ -170,7 +170,7 @@ public class Example1 extends JFrame {
 		 * H2 does not fully support updatable rowset so it must be
 		 * re-queried following insert and delete with rowset.execute()
 		 */
-		navigator.setDBNav(new SSDBNavImpl(this)
+		navigator.getNavigateActions().setDBNav(new SSDBNavImpl(this)
 		{
 			/**
 			 * Requery the rowset following a deletion. This is needed for H2.

--- a/swingset-demo/src/main/java/com/nqadmin/swingset/demo/Example2.java
+++ b/swingset-demo/src/main/java/com/nqadmin/swingset/demo/Example2.java
@@ -131,7 +131,7 @@ public class Example2 extends JFrame
 		 * H2 does not fully support updatable rowset so it must be
 		 * re-queried following insert and delete with rowset.execute()
 		 */
-		navigator.setDBNav(new SSDBNavImpl(this)
+		navigator.getNavigateActions().setDBNav(new SSDBNavImpl(this)
 		{
 			/**
 			 * Requery the rowset following a deletion. This is needed for H2.

--- a/swingset-demo/src/main/java/com/nqadmin/swingset/demo/Example3.java
+++ b/swingset-demo/src/main/java/com/nqadmin/swingset/demo/Example3.java
@@ -138,7 +138,7 @@ public class Example3 extends JFrame {
 		 * H2 does not fully support updatable rowset so it must be
 		 * re-queried following insert and delete with rowset.execute()
 		 */
-		navigator.setDBNav(new SSDBNavImpl(this) {
+		navigator.getNavigateActions().setDBNav(new SSDBNavImpl(this) {
 			/**
 			 * unique serial id
 			 */

--- a/swingset-demo/src/main/java/com/nqadmin/swingset/demo/Example4.java
+++ b/swingset-demo/src/main/java/com/nqadmin/swingset/demo/Example4.java
@@ -154,7 +154,7 @@ public class Example4 extends JFrame {
 			 * H2 does not fully support updatable rowset so it must be
 			 * re-queried following insert and delete with rowset.execute()
 			 */
-			navigator.setDBNav(new SSDBNavImpl(this) {
+			navigator.getNavigateActions().setDBNav(new SSDBNavImpl(this) {
 				/**
 				 * unique serial id
 				 */
@@ -288,7 +288,7 @@ public class Example4 extends JFrame {
 			// YOU HAVE TO CALL THE .async() METHOD
 			//
 			// AFTER CALLING .execute() ON THE COMBO NAVIGATOR, CALL THE .sync() METHOD
-				syncManager = new SSSyncManager(cmbSelectPart, navigator);
+				syncManager = new SSSyncManager(cmbSelectPart, navigator.getNavigateActions());
 				syncManager.setSyncColumnName("part_id");
 				syncManager.sync();
 

--- a/swingset-demo/src/main/java/com/nqadmin/swingset/demo/TestBaseComponents.java
+++ b/swingset-demo/src/main/java/com/nqadmin/swingset/demo/TestBaseComponents.java
@@ -302,7 +302,7 @@ public class TestBaseComponents extends JFrame
 		 * H2 does not fully support updatable rowset so it must be
 		 * re-queried following insert and delete with rowset.execute()
 		 */
-		navigator.setDBNav(new SSDBNavImpl(this)
+		navigator.getNavigateActions().setDBNav(new SSDBNavImpl(this)
 		{
 			/**
 			 * Requery the rowset following a deletion. This is needed for H2.
@@ -405,7 +405,7 @@ public class TestBaseComponents extends JFrame
 			// YOU HAVE TO CALL THE .async() METHOD
 			//
 			// AFTER CALLING .execute() ON THE COMBO NAVIGATOR, CALL THE .sync() METHOD
-			syncManager = new SSSyncManager(cmbSSDBComboNav, navigator);
+			syncManager = new SSSyncManager(cmbSSDBComboNav, navigator.getNavigateActions());
 			syncManager.setSyncColumnName("swingset_base_test_pk");
 			syncManager.sync();
 		}

--- a/swingset-demo/src/main/java/com/nqadmin/swingset/demo/TestFormattedComponents.java
+++ b/swingset-demo/src/main/java/com/nqadmin/swingset/demo/TestFormattedComponents.java
@@ -179,7 +179,7 @@ public class TestFormattedComponents extends JFrame {
 			 * H2 does not fully support updatable rowset so it must be
 			 * re-queried following insert and delete with rowset.execute()
 			 */
-			navigator.setDBNav(new SSDBNavImpl(this) {
+			navigator.getNavigateActions().setDBNav(new SSDBNavImpl(this) {
 				/**
 				 * Re-enable DB Navigator following insertion Cancel
 				 */
@@ -268,7 +268,7 @@ public class TestFormattedComponents extends JFrame {
 			// YOU HAVE TO CALL THE .async() METHOD
 			//
 			// AFTER CALLING .execute() ON THE COMBO NAVIGATOR, CALL THE .sync() METHOD
-				syncManager = new SSSyncManager(cmbSSDBComboNav, navigator);
+				syncManager = new SSSyncManager(cmbSSDBComboNav, navigator.getNavigateActions());
 				syncManager.setSyncColumnName("swingset_formatted_test_pk");
 				syncManager.sync();
 

--- a/swingset/pom.xml
+++ b/swingset/pom.xml
@@ -398,6 +398,13 @@
 						<configuration>
 							<release>${version.java}</release>
 							<failOnError>false</failOnError>
+							<additionalOptions>-html5</additionalOptions>
+							<doclint>all,-missing,-html</doclint>
+<!--
+							<links>
+								<link>https://javadoc.io/static/com.glazedlists/glazedlists/${version.glazedlists}</link>
+							</links>
+-->
 						</configuration>
 						<executions>
 							<execution>

--- a/swingset/src/main/java/com/nqadmin/swingset/SSDataNavigator.java
+++ b/swingset/src/main/java/com/nqadmin/swingset/SSDataNavigator.java
@@ -56,7 +56,6 @@ import javax.swing.event.ChangeEvent;
 
 import com.nqadmin.swingset.navigate.NavigateActions;
 import com.nqadmin.swingset.navigate.RowNumberSpinner;
-import com.nqadmin.swingset.navigate.RowSetState;
 
 import static com.nqadmin.swingset.navigate.NavAction.*;
 
@@ -122,7 +121,9 @@ public class SSDataNavigator extends JPanel
 		buttonSize = new Dimension(40, 20);
 
 		RowNumberSpinner.removeTinyArrows(rowNumberSpinner, rowSpinnerSize);
-		RowNumberSpinner.inWindowUpDownKeys(rowNumberSpinner);
+
+		rowNumberSpinner.setWindowUpDownKeysEnable(true);
+
 		rowNumberSpinner.addChangeListener((ChangeEvent e) -> {
 			updateLblRowCount();
 		});
@@ -151,7 +152,7 @@ public class SSDataNavigator extends JPanel
 		// Could allow null, use dummy with all buttons disabled
 		Objects.requireNonNull(rowSet);
 
-		RowSet oldValue = navActs.getRowSet();
+		RowSet oldValue = getRowSet();
 		installRowSet(rowSet);
 		firePropertyChange("rowSet", oldValue, rowSet);
 	}
@@ -214,6 +215,16 @@ public class SSDataNavigator extends JPanel
 		add(deleteButton);
 		add(lblRowCount);
 		// pack();
+	}
+
+	/**
+	 * Use the up/down arrow keys while this spinner's window is focused
+	 * to adjust row number.
+	 * 
+	 * @param enable true enables up/down keys when window has focus
+	 */
+	public void setWindowUpDownKeysEnable(boolean enable) {
+		rowNumberSpinner.setWindowUpDownKeysEnable(enable);
 	}
 
 	/**
@@ -291,11 +302,21 @@ public class SSDataNavigator extends JPanel
 	}
 
 	/**
+	 * Get the NavigateActions used by this GUI element.
+	 * @return associated NavigateActions
+	 */
+	public NavigateActions getNavigateActions() {
+		return navActs;
+	}
+
+	/**
 	 * Indicates if the navigator will skip the execute function call on the
 	 * underlying RowSet (needed for MySQL - see FAQ).
 	 *
 	 * @return value of execute() indicator
+	 * @deprecated use {@linkplain NavigateActions#getCallExecute()  }
 	 */
+	@Deprecated
 	public boolean getCallExecute() {
 		return navActs.getCallExecute();
 	}
@@ -305,7 +326,9 @@ public class SSDataNavigator extends JPanel
 	 *
 	 * @return returns true if a confirmation dialog is displayed when the user
 	 *         deletes a record, else false.
+	 * @deprecated use {@linkplain NavigateActions#getConfirmDeletes() }
 	 */
+	@Deprecated
 	public boolean getConfirmDeletes() {
 		return navActs.getConfirmDeletes();
 	}
@@ -315,7 +338,9 @@ public class SSDataNavigator extends JPanel
 	 * when the insert button is pressed to perform custom actions.
 	 *
 	 * @return any custom implementation of the SSDBNav interface
+	 * @deprecated use {@linkplain NavigateActions#getDBNav() }
 	 */
+	@Deprecated
 	public SSDBNav getDBNav() {
 		return navActs.getDBNav();
 	}
@@ -324,7 +349,9 @@ public class SSDataNavigator extends JPanel
 	 * Returns true if deletions are allowed, else false.
 	 *
 	 * @return returns true if deletions are allowed, else false.
+	 * @deprecated use {@linkplain NavigateActions#getDeletion()   }
 	 */
+	@Deprecated
 	public boolean getDeletion() {
 		return navActs.getDeletion();
 	}
@@ -333,7 +360,9 @@ public class SSDataNavigator extends JPanel
 	 * Returns true if insertions are allowed, else false.
 	 *
 	 * @return returns true if insertions are allowed, else false.
+	 * @deprecated use {@linkplain NavigateActions#getInsertion()   }
 	 */
+	@Deprecated
 	public boolean getInsertion() {
 		return navActs.getInsertion();
 	}
@@ -343,14 +372,18 @@ public class SSDataNavigator extends JPanel
 	 *
 	 * @return returns true if the user modifications are written back to the
 	 *         database, else false.
+	 * @deprecated use {@linkplain NavigateActions#getModification()   }
 	 */
+	@Deprecated
 	public boolean getModification() {
 		return navActs.getModification();
 	}
 
 	/**
 	 * @return the navCombo
+	 * @deprecated use {@linkplain NavigateActions#getNavCombo() 
 	 */
+	@Deprecated
 	public SSDBComboBox getNavCombo() {
 		return navActs.getNavCombo();
 	}
@@ -361,7 +394,7 @@ public class SSDataNavigator extends JPanel
 	 * @return returns the RowSet being used.
 	 */
 	public RowSet getRowSet() {
-		return navActs.getRowSet();
+		return navActs != null ? navActs.getRowSet() : null;
 	}
 	
 	/**
@@ -381,10 +414,24 @@ public class SSDataNavigator extends JPanel
 	}
 
 	/**
-	 * @return boolean indicating if the navigator is on an insert row
+	 * Returns true if the RowSet contains one or more rows, else false.
+	 *
+	 * @return return true if RowSet contains data else false.
+	 * @deprecated use {@linkplain NavigateActions#containsRows() }
 	 */
+	@Deprecated
+	public boolean containsRows()
+	{
+		return navActs.containsRows();
+	}
+
+	/**
+	 * @return boolean indicating if the navigator is on an insert row
+	 * @deprecated use {@linkplain NavigateActions#isOnInsertRow()   }
+	 */
+	@Deprecated
 	public boolean isOnInsertRow() {
-		return RowSetState.isInserting(navActs.getRowSet());
+		return navActs.isOnInsertRow();
 	}
 
 	/**
@@ -438,7 +485,9 @@ public class SSDataNavigator extends JPanel
 	 * underlying RowSet. This is necessary for MySQL (see FAQ).
 	 *
 	 * @param _callExecute false if using MySQL database - otherwise true
+	 * @deprecated use {@linkplain NavigateActions#setCallExecute(boolean)  }
 	 */
+	@Deprecated
 	public void setCallExecute(final boolean _callExecute) {
 		navActs.setCallExecute(_callExecute);
 	}
@@ -449,7 +498,9 @@ public class SSDataNavigator extends JPanel
 	 * value is true.
 	 *
 	 * @param _confirmDeletes indicates whether or not to confirm deletions
+	 * @deprecated use {@linkplain NavigateActions#setConfirmDeletes(boolean)   }
 	 */
+	@Deprecated
 	public void setConfirmDeletes(final boolean _confirmDeletes) {
 		navActs.setConfirmDeletes(_confirmDeletes);
 	}
@@ -460,7 +511,9 @@ public class SSDataNavigator extends JPanel
 	 * the insert button is pressed
 	 *
 	 * @param _dBNav implementation of the SSDBNav interface
+	 * @deprecated use {@linkplain NavigateActions#setDBNav(com.nqadmin.swingset.SSDBNav)}
 	 */
+	@Deprecated
 	public void setDBNav(final SSDBNav _dBNav) {
 		navActs.setDBNav(_dBNav);
 	}
@@ -470,7 +523,9 @@ public class SSDataNavigator extends JPanel
 	 * row deletions are not allowed. True by default.
 	 *
 	 * @param _deletion indicates whether or not to allow deletions
+	 * @deprecated use {@linkplain NavigateActions#setDeletion(boolean)}
 	 */
+	@Deprecated
 	public void setDeletion(final boolean _deletion) {
 		navActs.setDeletion(_deletion);
 	}
@@ -504,7 +559,9 @@ public class SSDataNavigator extends JPanel
 	 * row insertions are not allowed. True by default.
 	 *
 	 * @param _insertion indicates whether or not to allow insertions
+	 * @deprecated use {@linkplain NavigateActions#setInsertion(boolean) }
 	 */
+	@Deprecated
 	public void setInsertion(final boolean _insertion) {
 		navActs.setInsertion(_insertion);
 	}
@@ -516,14 +573,18 @@ public class SSDataNavigator extends JPanel
 	 *
 	 * @param _modification indicates whether or not the modification-related
 	 *                      buttons are enabled.
+	 * @deprecated use {@linkplain NavigateActions#setModification(boolean) }
 	 */
+	@Deprecated
 	public void setModification(final boolean _modification) {
 		navActs.setModification(_modification);
 	}
 
 	/**
 	 * @param _navCombo the navCombo to set
+	 * @deprecated use {@linkplain NavigateActions#setNavCombo(com.nqadmin.swingset.SSDBComboBox) }
 	 */
+	@Deprecated
 	public void setNavCombo(final SSDBComboBox _navCombo) {
 		navActs.setNavCombo(_navCombo);
 	}
@@ -538,7 +599,9 @@ public class SSDataNavigator extends JPanel
 	 * //		any navigation takes place, but can also be called manually.
 	 *
 	 * @return returns true if update succeeds else false.
+	 * @deprecated use {@linkplain NavigateActions#updatePresentRow() }
 	 */
+	@Deprecated
 	public boolean updatePresentRow() {
 		return navActs.updatePresentRow();
 	}

--- a/swingset/src/main/java/com/nqadmin/swingset/datasources/DateTime.java
+++ b/swingset/src/main/java/com/nqadmin/swingset/datasources/DateTime.java
@@ -159,6 +159,9 @@ public class DateTime
 					.put(SSFormat.DATE_MMDDYYYY_SLASH,
 							List.of(DateTimeFormatter.ofPattern("M/d/uuuu"),
 									DateTimeFormatter.ofPattern("MMdduuuu")))
+					.put(SSFormat.DATE_DDMMYYYY_SLASH,
+							List.of(DateTimeFormatter.ofPattern("d/M/uuuu"),
+									DateTimeFormatter.ofPattern("ddMMuuuu")))
 					.put(SSFormat.TIME_HHMMSS,
 							List.of(DateTimeFormatter.ISO_LOCAL_TIME,
 									DateTimeFormatter.ofPattern("HHmmss")))

--- a/swingset/src/main/java/com/nqadmin/swingset/formatting/SSDateField.java
+++ b/swingset/src/main/java/com/nqadmin/swingset/formatting/SSDateField.java
@@ -112,11 +112,10 @@ public class SSDateField extends DateTimeField {
 			formatMask = "##/##/####";
 			editPattern = "MMddyyyy";
 		}
-		//// TODO: DateTime needs to know the format to distinguish DDMM from MMDD
-		//case DATE_DDMMYYYY_SLASH -> {
-		//	formatMask = "##/##/####";
-		//	editPattern = "ddMMyyyy";
-		//}
+		case DATE_DDMMYYYY_SLASH -> {
+			formatMask = "##/##/####";
+			editPattern = "ddMMyyyy";
+		}
 		case DATE_YYYYMMDD_STROKE -> {
 			formatMask = "####-##-##";
 			editPattern = "yyyyMMdd";

--- a/swingset/src/main/java/com/nqadmin/swingset/navigate/NavigateActions.java
+++ b/swingset/src/main/java/com/nqadmin/swingset/navigate/NavigateActions.java
@@ -149,6 +149,16 @@ public class NavigateActions
 		REDO;
 	}
 
+	/**
+	 * Which key does increment/decrement.
+	 */
+	public enum UpDownKeysAction {
+		/** This is like data in a grid. */
+		UP_DECREMENT,
+		/** Up key increments. */
+		UP_INCREMENT,
+	}
+
 	/** Log4j Logger for component */
 	private static final Logger logger = SSUtils.getLogger();
 
@@ -429,6 +439,7 @@ public class NavigateActions
 		actions.put(NAV_GOTOROW,	new NavGotoRowAction());
 
 		rowNumberModel = new SpinnerNumberModel(1, 1, 1, 1);
+		setUpDownKeysAction(UpDownKeysAction.UP_DECREMENT);
 		actions.get(NAV_GOTOROW).putValue("SPINNER_MODEL", rowNumberModel);
 		undoRow = new UndoRow();
 
@@ -437,6 +448,18 @@ public class NavigateActions
 			return;
 		setupEventBus();
 		setupRowSet();
+	}
+
+	/**
+	 * Specifies how the up/down arrows increment/decrement.
+	 * However the up key is specified, the down key does the opposite.
+	 * @param act the up key behavior
+	 */
+	public final void setUpDownKeysAction(UpDownKeysAction act) {
+		int stepsize = act == UpDownKeysAction.UP_DECREMENT ? -1
+				: act == UpDownKeysAction.UP_INCREMENT ? 1 : 0;
+		if (stepsize != 0)
+			rowNumberModel.setStepSize(stepsize);
 	}
 
 	BusReceiver busReceiver; // Strong reference, other only weakly referenced.

--- a/swingset/src/main/java/com/nqadmin/swingset/navigate/RowNumberSpinner.java
+++ b/swingset/src/main/java/com/nqadmin/swingset/navigate/RowNumberSpinner.java
@@ -46,20 +46,21 @@ import java.awt.AWTEvent;
 import java.awt.Component;
 import java.awt.Dimension;
 import java.awt.event.ActionEvent;
-import java.awt.event.KeyEvent;
 import java.beans.PropertyChangeListener;
 
 import javax.swing.Action;
 import javax.swing.ComponentInputMap;
 import javax.swing.InputMap;
-import javax.swing.JComponent;
 import javax.swing.JSpinner;
-import javax.swing.KeyStroke;
 import javax.swing.SpinnerModel;
 import javax.swing.SpinnerNumberModel;
 import javax.swing.plaf.basic.BasicSpinnerUI;
 
 import com.nqadmin.swingset.navigate.NavigateActions.NavGotoRowAction;
+
+import static java.awt.event.KeyEvent.VK_DOWN;
+import static java.awt.event.KeyEvent.VK_UP;
+import static javax.swing.KeyStroke.getKeyStroke;
 
 /**
  * Spinner for {@linkplain javax.sql.RowSet}'s row number that accepts an Action;
@@ -166,29 +167,61 @@ public class RowNumberSpinner extends JSpinner
 	}
 
 	/**
-	 * Wider use of the specified component's up/down arrow keys.
-	 * @param comp
+	 * Get one of this component's local input maps. If it doesn't exist
+	 * then create it and hook it in to the component.
+	 * @return the specified input map
 	 */
-	public static void inWindowUpDownKeys(JComponent comp)
+	private InputMap getMyInputMap(int whichMap)
 	{
-		InputMap im = new ComponentInputMap(comp);
-		im.put(KeyStroke.getKeyStroke(KeyEvent.VK_UP, 0), "increment");
-		im.put(KeyStroke.getKeyStroke(KeyEvent.VK_DOWN, 0), "decrement");
-		im.setParent(comp.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW));
-		comp.setInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW, im);
+		return switch (whichMap) {
+		case WHEN_IN_FOCUSED_WINDOW -> {
+			if (inFocusedWindowInputMap == null) {
+				InputMap im = new ComponentInputMap(this);
+				im.setParent(getInputMap(WHEN_IN_FOCUSED_WINDOW));
+				setInputMap(WHEN_IN_FOCUSED_WINDOW, im);
+				inFocusedWindowInputMap = im;
+			}
+			yield inFocusedWindowInputMap;
+		}
+		case WHEN_ANCESTOR_OF_FOCUSED_COMPONENT -> {
+			if (ancestorOfFocusedComponentInputMap == null) {
+				InputMap im = new InputMap();
+				im.setParent(getInputMap(WHEN_ANCESTOR_OF_FOCUSED_COMPONENT));
+				setInputMap(WHEN_ANCESTOR_OF_FOCUSED_COMPONENT, im);
+				ancestorOfFocusedComponentInputMap = im;
+			}
+			yield ancestorOfFocusedComponentInputMap;
+		}
+		default -> null;
+		};
+	}
+
+	private InputMap inFocusedWindowInputMap;
+	private InputMap ancestorOfFocusedComponentInputMap;
+
+	/**
+	 * Use the up/down arrow keys while this spinner's window is focused
+	 * to adjust row number.
+	 * @param enable true enables up/down keys when window has focus
+	 */
+	public void setWindowUpDownKeysEnable(boolean enable)
+	{
+		InputMap im = getMyInputMap(WHEN_IN_FOCUSED_WINDOW);
+		im.put(getKeyStroke(VK_UP, 0), enable ? "increment" : null);
+		im.put(getKeyStroke(VK_DOWN, 0), enable ? "decrement" : null);
 	}
 
 	/**
-	 * Disable the specified component's up/down arrow keys.
-	 * @param comp
+	 * Disable the up/down arrow keys for this spinner component.
+	 * When disabling, window up/down keys are disabled
+	 * using {@link RowNumberSpinner#setWindowUpDownKeysEnable(boolean)}.
+	 * 
+	 * @param enable true enables default
 	 */
-	public static void disableUpDownKeys(JComponent comp)
+	public void setUpDownKeysEnable(boolean enable)
 	{
-		InputMap im = new InputMap();
-		im.put(KeyStroke.getKeyStroke(KeyEvent.VK_UP, 0), "none");
-		im.put(KeyStroke.getKeyStroke(KeyEvent.VK_DOWN, 0), "none");
-		im.setParent(comp.getInputMap(JComponent.WHEN_ANCESTOR_OF_FOCUSED_COMPONENT));
-		comp.setInputMap(JComponent.WHEN_ANCESTOR_OF_FOCUSED_COMPONENT, im);
+		InputMap im = getMyInputMap(WHEN_ANCESTOR_OF_FOCUSED_COMPONENT);
+		im.put(getKeyStroke(VK_UP, 0), enable ? null : "none");
+		im.put(getKeyStroke(VK_DOWN, 0), enable ? null : "none");
 	}
-
 }

--- a/swingset/src/main/java/com/nqadmin/swingset/navigate/RowSetState.java
+++ b/swingset/src/main/java/com/nqadmin/swingset/navigate/RowSetState.java
@@ -53,10 +53,9 @@ import javax.sql.rowset.spi.SyncProviderException;
 import com.google.common.collect.MapMaker;
 
 
-
 /**
- *
- * @author err
+ * Track some global state for a row set.
+ * Access to some of this state is delegate to other classes in this package.
  */
 public class RowSetState
 {
@@ -78,6 +77,7 @@ public class RowSetState
 		}
 	}
 
+	// NOTE: only invoked from one method which is syncronized.
 	static void setNavigateActions(RowSet rs, NavigateActions navigator) {
 		if (rs != null) {
 			getRowSetState(rs).refNavigateActions = new WeakReference<>(navigator);
@@ -161,7 +161,7 @@ public class RowSetState
 	 * @param rs get information for this RowSet
 	 * @return the associated data navigator
 	 */
-	public static NavigateActions getNavigateActions(RowSet rs) {
+	static NavigateActions getNavigateActions(RowSet rs) {
 		return rs == null ? null : getRowSetState(rs).refNavigateActions.get();
 	}
 	

--- a/swingset/src/main/java/com/nqadmin/swingset/utils/SSFormViewScreenHelper.java
+++ b/swingset/src/main/java/com/nqadmin/swingset/utils/SSFormViewScreenHelper.java
@@ -56,6 +56,7 @@ import com.nqadmin.swingset.SSDBComboBox;
 import com.nqadmin.swingset.SSDBNavImpl;
 import com.nqadmin.swingset.SSDataNavigator;
 import com.nqadmin.swingset.SSTextField;
+import com.nqadmin.swingset.navigate.NavigateActions;
 import com.nqadmin.swingset.utils.SSEnums.Navigation;
 
 //SSFormViewScreenHelper.java
@@ -266,8 +267,9 @@ public abstract class SSFormViewScreenHelper extends SSScreenHelperCommon {
 	private String comboNavDisplayColumn2 = null; // name of the 2nd database column to display in the combo navigator
 	private String comboNavSeparator = null; // character(s) used to separate the display of the 1st and 2nd columns  of the combo navigator
 	
+	private NavigateActions navigateActions; // Navigate actions.
+	private SSSyncManager syncManager; // SYNC DB NAV COMBO and NAVIGATION
 	private SSDataNavigator dataNavigator; // Data navigator.
-	private SSSyncManager syncManager; // SYNC DB NAV COMBO and NAVIGATOR
 	
 	private boolean requeryAfterInsertOrDelete = false; // for some databases like H2, you have to call .execute() on the rowset following insertion or deletion
 
@@ -355,11 +357,11 @@ public abstract class SSFormViewScreenHelper extends SSScreenHelperCommon {
 
 	/**
 	 * Create syncManager if it doesn't exist and sync cmbNavigator and
-	 * dataNavigator
+	 * navigate actions.
 	 */
 	private void activateSyncManager() {
 		if (getSyncManager() == null) {
-			setSyncManager(new SSSyncManager(getComboNav(), getDataNavigator()));
+			setSyncManager(new SSSyncManager(getComboNav(), getNavigateActions()));
 			getSyncManager().setSyncColumnName(getPkColumn());
 		}
 
@@ -392,7 +394,7 @@ public abstract class SSFormViewScreenHelper extends SSScreenHelperCommon {
 			// UPDATE PRESENT ROW WHEN SCREEN LOOSES FOCUS
 			@Override
 			public void internalFrameDeactivated(final InternalFrameEvent ife) {
-				getDataNavigator().updatePresentRow();
+				getNavigateActions().updatePresentRow();
 			}
 		});
 
@@ -417,7 +419,7 @@ public abstract class SSFormViewScreenHelper extends SSScreenHelperCommon {
 	protected abstract void bindComponents() throws Exception;
 
 	/**
-	 * Deactivate sync between cmbNavigator and dataNavigator.
+	 * Deactivate sync between cmbNavigator and navigate actions.
 	 */
 	private void deactivateSyncManager() {
 		if (getSyncManager() != null) {
@@ -469,7 +471,16 @@ public abstract class SSFormViewScreenHelper extends SSScreenHelperCommon {
 	 * @return the dataNavigator
 	 */
 	protected SSDataNavigator getDataNavigator() {
+		if (dataNavigator == null)
+			dataNavigator = new SSDataNavigator(getRowset());
 		return dataNavigator;
+	}
+
+	/**
+	 * @return the navigateActions
+	 */
+	protected NavigateActions getNavigateActions() {
+		return navigateActions;
 	}
 	
 	/**
@@ -522,11 +533,11 @@ public abstract class SSFormViewScreenHelper extends SSScreenHelperCommon {
 	}
 
 	/**
-	 * Initialize dataNavigator
+	 * Initialize navigateActions
 	 */
-	private void initDataNavigator() {
-		setDataNavigator(new SSDataNavigator(getRowset()));
-		getDataNavigator().setDBNav(new FormHelperSSDBNavImpl(this));
+	private void initNavigatorActions() {
+		updateNavigateActions();
+		getNavigateActions().setDBNav(new FormHelperSSDBNavImpl(this));
 	}
 
 	/**
@@ -551,8 +562,8 @@ public abstract class SSFormViewScreenHelper extends SSScreenHelperCommon {
 			// SET ROWSET QUERY
 			initRowset();
 
-			// INITIALIZE DATA NAVIGATOR
-			initDataNavigator();
+			// INITIALIZE NAVIGATION ACTIONS
+			initNavigatorActions();
 			
 			// INITIALIZE COMBO NAVIGATOR
 			initComboNav();
@@ -658,10 +669,10 @@ public abstract class SSFormViewScreenHelper extends SSScreenHelperCommon {
 	}
 
 	/**
-	 * @param _dataNavigator the data navigator to use for this screen/form
+	 * @param _navigateActions the navigate actions to use for this screen/form
 	 */
-	private void setDataNavigator(final SSDataNavigator _dataNavigator) {
-		dataNavigator = _dataNavigator;
+	private void setNavigateActions(NavigateActions _navigateActions) {
+		navigateActions = _navigateActions;
 	}
 	
 	/**
@@ -785,10 +796,10 @@ public abstract class SSFormViewScreenHelper extends SSScreenHelperCommon {
 	}
 
 	/**
-	 * Update data navigator with latest rowset
+	 * Update navigate actions with latest rowset
 	 */
-	private void updateDataNavigator() {
-		getDataNavigator().setRowSet(getRowset());
+	private void updateNavigateActions() {
+		setNavigateActions(NavigateActions.get(getRowset()));
 	}
 
 	/**
@@ -809,7 +820,7 @@ public abstract class SSFormViewScreenHelper extends SSScreenHelperCommon {
 			updateRowset();
 
 			// SET NEW ROWSET FOR NAVIGATOR.
-			updateDataNavigator();
+			updateNavigateActions();
 			
 			// UPDATE THE COMBO NAVIGATOR
 			updateComboNav();

--- a/swingset/src/main/java/com/nqadmin/swingset/utils/SSSyncManager.java
+++ b/swingset/src/main/java/com/nqadmin/swingset/utils/SSSyncManager.java
@@ -52,7 +52,7 @@ import java.lang.System.Logger;
 import static java.lang.System.Logger.Level.*;
 
 import com.nqadmin.swingset.SSDBComboBox;
-import com.nqadmin.swingset.SSDataNavigator;
+import com.nqadmin.swingset.navigate.NavigateActions;
 
 import static com.nqadmin.swingset.utils.SSUtils.sf;
 //import com.nqadmin.swingset.models.SSListItem;
@@ -82,6 +82,7 @@ public class SSSyncManager {
 
 		// WHEN THERE IS A CHANGE IN THIS VALUE MOVE THE ROWSET SO THAT
 		// ITS POSITIONED AT THE RIGHT RECORD.
+		/** {@inheritDoc } */
 		@Override
 		public void actionPerformed(final ActionEvent ae) {
 
@@ -114,7 +115,7 @@ public class SSSyncManager {
 					//
 					// 2020-12-02_BP: adding back
 					// 2021-02-26_BP: moving inside 'if (comboPK != rowsetPK) {' block
-					dataNavigator.updatePresentRow();
+					navigateActions.updatePresentRow();
 					
 					// long indexOfId = SSSyncManager.this.comboBox.itemMap.get(this.id) + 1;
 					final int indexOfPK = comboBox.getMappings().indexOf(comboPK) + 1;
@@ -147,8 +148,8 @@ public class SSSyncManager {
 							// If there are only a few records, just start at first record
 							int rowsetSearchFrom = 1;
 
-							if (numRecords>offsetToCheck) {
-								rowsetSearchFrom = indexOfPK - offsetToCheck;
+							if (numRecords>OFFSET_TO_CHECK) {
+								rowsetSearchFrom = indexOfPK - OFFSET_TO_CHECK;
 							}
 							if (rowsetSearchFrom<1) {
 								rowsetSearchFrom += numRecords;
@@ -162,7 +163,7 @@ public class SSSyncManager {
 						// number of items in combo is the number of records in resultset.
 						// so if for some reason item is in combo but deleted in rowset
 						// To avoid infinite loop in such scenario
-						if (count > (numRecords + overlapToCheck)) {
+						if (count > (numRecords + OVERLAP_TO_CHECK)) {
 							comboBox.repaint();
 							logger.log(WARNING, "SSSyncManager unable to find a record matching the selection in the dropdown list: " + comboBox.getSelectedStringValue() + ".");
 							// JOptionPane.showInternalMessageDialog(this,"Record deleted. Info the admin
@@ -247,17 +248,19 @@ public class SSSyncManager {
 	/**
 	 * Log4j Logger for component
 	 */
-	private static Logger logger = SSUtils.getLogger();
+	private static final Logger logger = SSUtils.getLogger();
 
 	/**
-	 * # of records to step back if doing a sequential search because SSDBComboBox and RowSet results don't match.
+	 * # of records to step back if doing a sequential search because
+	 * SSDBComboBox and RowSet results don't match.
 	 */
-	private static final int offsetToCheck = 7;
+	private static final int OFFSET_TO_CHECK = 7;
 
 	/**
-	 * # of records of overlap to check if SSDBComboBox and RowSet results don't match due to record additions/deletions.
+	 * # of records of overlap to check if SSDBComboBox and RowSet results
+	 * don't match due to record additions/deletions.
 	 */
-	private static final int overlapToCheck = 7;
+	private static final int OVERLAP_TO_CHECK = 7;
 
 	/**
 	 * SSDBComboBox used for record navigation.
@@ -275,9 +278,9 @@ public class SSSyncManager {
 	private boolean comboListenerAdded = false;
 
 	/**
-	 * SSDataNavigator to be synchronized with navigation combo box.
+	 * NavigateActions to be synchronized with navigation combo box.
 	 */
-	private SSDataNavigator dataNavigator;
+	private NavigateActions navigateActions;
 
 	/**
 	 * RowSet navigated with data navigator and combo box.
@@ -302,22 +305,34 @@ public class SSSyncManager {
 
 
 	/**
-	 * <p>
 	 * Creates a SSSyncManager with the specified combo box and data navigator.
 	 *
-	 * @param _comboBox      SSDBComboBox used for record navigation
-	 * @param _dataNavigator SSDataNavigator to be synchronized with navigation
+	 * @param comboBox      SSDBComboBox used for record navigation
+	 * @param navigateActions NavigateActions to be synchronized with navigation
 	 *                       combo box
 	 */
-	public SSSyncManager(final SSDBComboBox _comboBox, final SSDataNavigator _dataNavigator) {
-		comboBox = _comboBox;
-		dataNavigator = _dataNavigator;
-		rowset = dataNavigator.getRowSet();
-		dataNavigator.setNavCombo(comboBox);
-		if (_comboBox.getLogColumnName() == null) {
-			_comboBox.setLogColumnName(sf("**ComboBoxNavigator@%x**",
-					System.identityHashCode(_comboBox)));
+	public SSSyncManager(SSDBComboBox comboBox, NavigateActions navigateActions) {
+		this.comboBox = comboBox;
+		this.navigateActions = navigateActions;
+		this.rowset = navigateActions.getRowSet();
+		navigateActions.setNavCombo(comboBox);
+		if (comboBox.getLogColumnName() == null) {
+			comboBox.setLogColumnName(sf("**ComboBoxNavigator@%x**",
+					System.identityHashCode(comboBox)));
 		}
+	}
+
+	/**
+	 * Creates a SSSyncManager with the specified combo box and data navigator.
+	 * 
+	 * @param comboBox combobox
+	 * @param dataNavigator data navigator
+	 * @deprecated use {@linkplain SSSyncManager#SSSyncManager(com.nqadmin.swingset.SSDBComboBox, com.nqadmin.swingset.navigate.NavigateActions) }
+	 */
+	@Deprecated
+	public SSSyncManager(SSDBComboBox comboBox, com.nqadmin.swingset.SSDataNavigator dataNavigator)
+	{
+		this(comboBox, dataNavigator.getNavigateActions());
 	}
 	
 	/**
@@ -343,7 +358,7 @@ public class SSSyncManager {
 	 */
 	private void addRowsetListener() {
 		if (!rowsetListenerAdded) {
-			dataNavigator.getRowSet().addRowSetListener(rowsetListener);
+			navigateActions.getRowSet().addRowSetListener(rowsetListener);
 			rowsetListenerAdded = true;
 		}
 	}
@@ -417,7 +432,7 @@ public class SSSyncManager {
 	 */
 	private void removeRowsetListener() {
 		if (rowsetListenerAdded) {
-			dataNavigator.getRowSet().removeRowSetListener(rowsetListener);
+			navigateActions.getRowSet().removeRowSetListener(rowsetListener);
 			rowsetListenerAdded = false;
 		}
 	}
@@ -435,11 +450,22 @@ public class SSSyncManager {
 	/**
 	 * Sets data navigator to be synchronized.
 	 *
-	 * @param _dataNavigator data navigator to be synchronized
+	 * @param dataNavigator data navigator to be synchronized
+	 * @deprecated use {@linkplain SSSyncManager#setDataNavigator(com.nqadmin.swingset.navigate.NavigateActions) }
 	 */
-	public void setDataNavigator(final SSDataNavigator _dataNavigator) {
-		dataNavigator = _dataNavigator;
-		rowset = dataNavigator.getRowSet();
+	@Deprecated
+	public void setDataNavigator(com.nqadmin.swingset.SSDataNavigator dataNavigator) {
+		setDataNavigator(dataNavigator.getNavigateActions());
+	}
+
+	/**
+	 * Sets navigate actions to synchronize.
+	 *
+	 * @param navigateActions data navigator to be synchronized
+	 */
+	public void setDataNavigator(NavigateActions navigateActions) {
+		this.navigateActions = navigateActions;
+		this.rowset = navigateActions.getRowSet();
 	}
 	
 	/**

--- a/swingset/src/test/java/com/nqadmin/swingset/datasources/RowSetOpsTest.java
+++ b/swingset/src/test/java/com/nqadmin/swingset/datasources/RowSetOpsTest.java
@@ -47,7 +47,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import com.nqadmin.swingset.mock.H2;
-import com.nqadmin.swingset.mock.TestingNavigate;
+import com.nqadmin.swingset.mock.NavigateHook;
 import com.nqadmin.swingset.utils.SSComponentInterface;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -100,7 +100,7 @@ public class RowSetOpsTest
 		RowSet rs = H2.getRowSet(null);
 		rs.setCommand("SELECT * FROM tbl");
 		@SuppressWarnings("UnusedAssignment")
-		TestingNavigate nav = new TestingNavigate(rs);
+		NavigateHook nav = new NavigateHook(rs);
 
 		Object fetch;
 		// Expected from the database
@@ -129,7 +129,7 @@ public class RowSetOpsTest
 									('2000-02-22','22:22:22','2222-02-22') ;
             """);
 		rs.setCommand("SELECT * FROM tbl");
-		nav = new TestingNavigate(rs);
+		nav = new NavigateHook(rs);
 
 		assertEquals(2, nav.rowCount());
 		fetch = RowSetOps.getColumnObject(RSC.getEx(rs, 1));
@@ -168,7 +168,7 @@ public class RowSetOpsTest
 
 		RowSet rs = H2.getRowSet(null);
 		rs.setCommand("SELECT * FROM tbl");
-		new TestingNavigate(rs);
+		new NavigateHook(rs);
 
 		Object fetch;
 		Timestamp fetch2;

--- a/swingset/src/test/java/com/nqadmin/swingset/mock/NavigateHook.java
+++ b/swingset/src/test/java/com/nqadmin/swingset/mock/NavigateHook.java
@@ -42,13 +42,13 @@ import static com.nqadmin.swingset.navigate.NavAction.*;
  *
  * @author err
  */
-public class TestingNavigate
+public class NavigateHook
 {
 	private final NavigateActions navActs;
 	private final ActionMap actionMap;
 
 	//public Navigate(NavigateActions navActs)
-	public TestingNavigate(RowSet rs)
+	public NavigateHook(RowSet rs)
 	{
 		this.navActs = NavigateActions.get(rs);
 		actionMap = navActs.createActionMap();


### PR DESCRIPTION
Added support for DATE_DDMMYYYY_SLASH.
Added SSDataNavigator::containsRow().
Rework nav up/down keys, behavioral options.
Deprecate NavigateActions found in SSDataNavigator in favor of direct access. Added SSDataNavigator::getNavigateActions().
Fix swingset/pom javadoc.
Rename TestingNavigate to NavigateHook.
Add NOTES/TODO.