### PR TITLE
No undo/redo for insert row; ConvertType/SSCheckBox nulls.

### DIFF
--- a/NOTES/TODO
+++ b/NOTES/TODO
@@ -25,6 +25,10 @@ in the Navigation changes, the SSDataNavigator detects this event and adjusts
 accordingly.
 
 ---
+RowSetState why not both weak keys and weak values. Problem is that state
+for inserting/acceptingChanges is allowed without NavigateActions.
+
+---
 Should the methods in SSDataNavigator that delegate to getNavigatorActions()
 be deprecated? If NavigatorActions are considered a model, then there's
 some precedence to keep some of them for convenience.

--- a/swingset/src/main/java/com/nqadmin/swingset/SSCheckBox.java
+++ b/swingset/src/main/java/com/nqadmin/swingset/SSCheckBox.java
@@ -200,7 +200,8 @@ public class SSCheckBox extends JCheckBox implements SSComponentInterface
 		final String text = getBoundColumnText();
 		logger.log(DEBUG, () -> sf("%s: getBoundColumnText() - %s",getColumnForLog(), text));
 
-		setSelected(getBoundColumnObject(Boolean.class));
+		Boolean value = getBoundColumnObject(Boolean.class);
+		setSelected(value == null ? false : value);
 	} // end protected void updateSSComponent() {
 
 	/** {@inheritDoc} */

--- a/swingset/src/main/java/com/nqadmin/swingset/datasources/ConvertType.java
+++ b/swingset/src/main/java/com/nqadmin/swingset/datasources/ConvertType.java
@@ -304,7 +304,7 @@ public class ConvertType
 	 */
 	private static Object internalConvertObject(Object sourceValue, Class<?> type)
 	{
-		if (type.isAssignableFrom(sourceValue.getClass()))
+		if (sourceValue == null || type.isAssignableFrom(sourceValue.getClass()))
 			return sourceValue;
 
 		Clazz source = getClazz(sourceValue.getClass());

--- a/swingset/src/main/java/com/nqadmin/swingset/datasources/RowSetOps.java
+++ b/swingset/src/main/java/com/nqadmin/swingset/datasources/RowSetOps.java
@@ -354,11 +354,9 @@ public class RowSetOps {
 		try {
 			if (getColumnCount(comp.getRowSet())==0)
 				return null;
-			Object objectValue = NavigateActions.fetchCurrentValue(comp);
-			if (objectValue == null)
-				return null;
-
-			return (Array) objectValue;
+			return (Array)(NavigateActions.isUndoRedoEnabled(comp)
+					? NavigateActions.fetchCurrentValue(comp)
+					: comp.getRowSet().getArray(comp.getBoundColumnIndex()));
 		} catch (SQLException ex) {
 			logger.log(ERROR, "SQL Exception for column " + comp.getBoundColumnName() + ".", ex);
 		}
@@ -376,7 +374,9 @@ public class RowSetOps {
 	 */
 	public static Object getColumnObject(RSC comp) throws SQLException
 	{
-		return NavigateActions.fetchCurrentValue(comp); // undo/redo
+		return NavigateActions.isUndoRedoEnabled(comp)
+				? NavigateActions.fetchCurrentValue(comp)
+				: comp.getRowSet().getObject(comp.getBoundColumnIndex());
 	}
 
 	/**
@@ -473,7 +473,9 @@ public class RowSetOps {
 	private static <T> T getColumnObject1(RSC comp, Class<T> type)
 			throws SQLException
 	{
-		Object objectValue = NavigateActions.fetchCurrentValue(comp);
+		Object objectValue = NavigateActions.isUndoRedoEnabled(comp)
+				? NavigateActions.fetchCurrentValue(comp)
+				: comp.getRowSet().getObject(comp.getBoundColumnIndex());
 		return convertObjectType(objectValue, type);
 	}
 
@@ -558,7 +560,9 @@ public class RowSetOps {
 				return null;
 			}
 
-			Object objectValue = NavigateActions.fetchCurrentValue(comp);
+			Object objectValue = NavigateActions.isUndoRedoEnabled(comp)
+					? NavigateActions.fetchCurrentValue(comp)
+					: comp.getRowSet().getObject(comp.getBoundColumnIndex());
 			if (objectValue == null)
 				return null;
 
@@ -752,8 +756,7 @@ public class RowSetOps {
 	{
 		logger.log(DEBUG, "[" + _columnName + "]. Update to: " + _updatedValue + ". Allow null? [" + _allowNull + "]");
 
-		if (NavigateActions.ENABLE_UNDO_REDO)
-			NavigateActions.captureInitialValue(comp);
+		NavigateActions.captureInitialValue(comp); // undo/redo
 
 		// On insert row, write null if updatedValue is null, and do not perform other checks. 
 		boolean did_update = false;
@@ -807,8 +810,7 @@ public class RowSetOps {
 		boolean _allowNull = comp.getAllowNull();
 		logger.log(DEBUG,  comp.getColumnForLog() + " Update to: " + _updatedValue + ". Allow null? [" + _allowNull + "]");
 
-		if (NavigateActions.ENABLE_UNDO_REDO)
-			NavigateActions.captureInitialValue(comp);
+		NavigateActions.captureInitialValue(comp); // undo/redo
 
 		boolean did_update = false;
 		try {
@@ -963,8 +965,7 @@ public class RowSetOps {
 			return;
 		}
 
-		if (NavigateActions.ENABLE_UNDO_REDO)
-			NavigateActions.captureInitialValue(comp);
+		NavigateActions.captureInitialValue(comp); // undo/redo
 
 		boolean did_update = false;
 		try {

--- a/swingset/src/main/java/com/nqadmin/swingset/navigate/NavigateActions.java
+++ b/swingset/src/main/java/com/nqadmin/swingset/navigate/NavigateActions.java
@@ -139,8 +139,6 @@ import static com.nqadmin.swingset.utils.SSUtils.sf;
  */
 public class NavigateActions
 {
-	/** False if no undo/redo and disables related code. */
-	public static final boolean ENABLE_UNDO_REDO = true;
 	/** Undo/redo commands */
 	public static enum UndoRedo {
 		/** Undo command */
@@ -209,16 +207,48 @@ public class NavigateActions
 	}
 
 	/**
-         * Make sure the column's undo/redo stack is initialized; the
-         * database value (an object) is the base.
-         * This must be used before any updates are done to the rowset.
+	 * Check if the specified {@linkplain RowSet} is currently enabled
+	 * for undo/redo. The enable state may only change when the RowSet's
+	 * current row changes.
+	 * @param rs RowSet of interest
+	 * @return true if undo/redo is OK
+	 */
+	public static boolean isUndoRedoEnabled(RowSet rs)
+	{
+		return !get(rs).isOnInsertRow();
+		//return false;
+
+		//return NavigateActions.ENABLE_UNDO_REDO && !get(rs).isOnInsertRow();
+		//return NavigateActions.ENABLE_UNDO_REDO;
+	}
+
+	/**
+	 * Check if the specified {@linkplain RSC} is currently enabled
+	 * for undo/redo. The enable state may only change when the RowSet's
+	 * current row changes.
+	 * <p>
+	 * This method currently delegates to check the rowset. In the future
+	 * it's possible that per column enable may be implemented.
+	 * @param comp RSC of interest
+	 * @return true if undo/redo is OK
+	 */
+	public static boolean isUndoRedoEnabled(RSC comp)
+	{
+		return isUndoRedoEnabled(comp.getRowSet());
+	}
+
+	/**
+	 * Make sure the column's undo/redo stack is initialized; the
+	 * database value (an object) is the base.
+	 * This must be used before any updates are done to the rowset.
 	 * @param comp rowset/column
 	 * @throws SQLException
 	 */
-	public static void captureInitialValue(SSComponentInterface comp) throws SQLException
+	public static void captureInitialValue(SSComponentInterface comp)
+			throws SQLException
 	{
-		if (!NavigateActions.ENABLE_UNDO_REDO)
-			throw new IllegalStateException("UNDO/REDO disabled");
+		if (!isUndoRedoEnabled(comp))
+			return;
 		NavigateActions navActs = get(comp.getRowSet());
 		navActs.undoRow.captureInitialValue(comp);
 	}
@@ -229,9 +259,10 @@ public class NavigateActions
 	 * @return current value
 	 * @throws SQLException
 	 */
-	public static Object fetchCurrentValue(RSC comp) throws SQLException
+	public static Object fetchCurrentValue(RSC comp)
+			throws SQLException
 	{
-		if (!NavigateActions.ENABLE_UNDO_REDO)
+		if (!isUndoRedoEnabled(comp))
 			throw new IllegalStateException("UNDO/REDO disabled");
 		NavigateActions navActs = get(comp.getRowSet());
 		return navActs.undoRow.fetchCurrentValue(comp);
@@ -244,8 +275,8 @@ public class NavigateActions
 	 */
 	public static void undoRedo(SSComponentInterface comp, UndoRedo cmd)
 	{
-		if (!NavigateActions.ENABLE_UNDO_REDO)
-			throw new IllegalStateException("UNDO/REDO disabled");
+		if (!isUndoRedoEnabled(comp))
+			return;
 		logger.log(DEBUG, () -> sf("%s: %s for %s", cmd,
 				comp.getClass().getSimpleName(), comp.getBoundColumnName()));
 		try {
@@ -269,8 +300,8 @@ public class NavigateActions
 	 */
 	public static void newSlot(SSComponentInterface comp)
 	{
-		if (!NavigateActions.ENABLE_UNDO_REDO)
-			throw new IllegalStateException("UNDO/REDO disabled");
+		if (!isUndoRedoEnabled(comp))
+			return;
 		NavigateActions navActs = get(comp.getRowSet());
 		navActs.undoRow.focusChange(null);
 	}
@@ -282,7 +313,7 @@ public class NavigateActions
 	 */
 	public static void addUndoableChange(RowSetModificationEvent ev) throws SQLException
 	{
-		if (!NavigateActions.ENABLE_UNDO_REDO)
+		if (!isUndoRedoEnabled(ev.getSource()))
 			return;
 		NavigateActions navActs = get(ev.getSource().getRowSet());
 		navActs.undoRow.addChange(ev);
@@ -570,7 +601,7 @@ public class NavigateActions
 	// TODO: Should this be public? NO, go through the static method in this class
 	Object doUndoRedo(SSComponentInterface comp, UndoRedo cmd) throws SQLException
 	{
-		if (!NavigateActions.ENABLE_UNDO_REDO)
+		if (!isUndoRedoEnabled(comp))
 			throw new IllegalStateException("UNDO/REDO disabled");
 		Object value = undoRow.doUndoRedo(comp, cmd);
 		updateActionState();

--- a/swingset/src/main/java/com/nqadmin/swingset/navigate/UndoRow.java
+++ b/swingset/src/main/java/com/nqadmin/swingset/navigate/UndoRow.java
@@ -133,7 +133,10 @@ final class UndoRow
 	// 	return false;
 	// }
 
-	/** force the capture of the database column for the comp. */
+	/**
+	 * Force the capture of the database column for the comp;
+	 * does nothing if the column is already captured.
+	 */
 	void captureInitialValue(SSComponentInterface comp) throws SQLException
 	{
 		getCol(comp);

--- a/swingset/src/main/java/com/nqadmin/swingset/utils/SSCommon.java
+++ b/swingset/src/main/java/com/nqadmin/swingset/utils/SSCommon.java
@@ -860,11 +860,12 @@ public class SSCommon
 
 		try {
 			if (getRowSet().getRow() != 0) {
-				if (NavigateActions.ENABLE_UNDO_REDO) {
-					value = RowSetOps.getColumnObjectText(ssComponent);
-				} else {
-					value = RowSetOps.getColumnText(getSSComponent());
-				}
+				// if (NavigateActions.ENABLE_UNDO_REDO) {
+				// 	value = RowSetOps.getColumnObjectText(ssComponent);
+				// } else {
+				// 	value = RowSetOps.getColumnText(getSSComponent());
+				// }
+				value = RowSetOps.getColumnObjectText(ssComponent);
 				if (!getAllowNull() && (value == null)) {
 					value = "";
 				}
@@ -1288,8 +1289,6 @@ public class SSCommon
 	 */
 	public static void setupUndoRedoKeys(SSComponentInterface comp)
 	{
-		if (!NavigateActions.ENABLE_UNDO_REDO)
-			return;
 		logger.log(DEBUG, () -> sf("UndoRedoKeys: %s", comp.getClass().getSimpleName()));
 
 		JComponent jc = (JComponent)comp;
@@ -1332,7 +1331,7 @@ public class SSCommon
 	 */
 	public void undoRedoUpdateObject(UndoRedo cmd, Object value) throws SQLException
 	{
-		if (!NavigateActions.ENABLE_UNDO_REDO)
+		if (!NavigateActions.isUndoRedoEnabled(ssComponent))
 			throw new IllegalStateException("UNDO/REDO disabled");
 		logger.log(DEBUG, () -> sf("%s: %s", cmd, value));
 


### PR DESCRIPTION
Introduce NavigateActions.isUndoRedoEnabled(comp/rowset) and disable undo/redo on insertRow (at least for now). Remove ENABLE_UNDO_REDO.
ConvertType::internalConvertObject handle conversion of null. Fix SSCheckBox, add check for null value in database column.